### PR TITLE
Add breadcrumbs to topbar across all main views

### DIFF
--- a/app/assets/css/layout/_content.scss
+++ b/app/assets/css/layout/_content.scss
@@ -20,7 +20,24 @@ div#content-wrapper {
         padding: 20px;
         margin-bottom: 20px;
         box-shadow: 0 .15rem 1.75rem 0 rgba(58,59,69,.15)!important;
-        height: 80px;
+
+        .breadcrumb {
+            font-size: 0.78rem;
+            background-color: transparent;
+            padding: 0;
+            margin: 4px 0 0;
+
+            a {
+                color: var(--colorPrimary);
+                &:hover { opacity: 0.75; text-decoration: none; }
+            }
+
+            .breadcrumb-item,
+            .breadcrumb-item.active,
+            .breadcrumb-item + .breadcrumb-item::before {
+                color: #adb5bd;
+            }
+        }
     }
 
     .text-primary {

--- a/app/templates/agreement_line/order_details.html.twig
+++ b/app/templates/agreement_line/order_details.html.twig
@@ -2,6 +2,16 @@
 
 {% block title %}{{ title }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item"><a href="{{ path('agreements_show') }}">Lista zamówień</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Panel zamówienia</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
     <single-order :line-id="{{ agreementLineId }}" :task-statuses="{{ taskStatuses|json_encode }}"></single-order>
 {% endblock %}

--- a/app/templates/base.html.twig
+++ b/app/templates/base.html.twig
@@ -23,13 +23,19 @@
 
         <div id="content-wrapper" class="d-flex flex-column">
 
-            <div class="topbar d-flex justify-content-between">
+            <div class="topbar">
 
-                <div class="p-1">
-                    {% include('_language_switcher.html.twig') %}
+                <div class="d-flex align-items-center justify-content-between">
+                    <div class="p-1">
+                        {% include('_language_switcher.html.twig') %}
+                    </div>
+                    <context-menu />
                 </div>
 
-                <context-menu />
+                <div class="d-flex justify-content-end">
+                    {% block breadcrumbs %}{% endblock %}
+                </div>
+
             </div>
 
             <!-- Main Content -->

--- a/app/templates/configuration/role.html.twig
+++ b/app/templates/configuration/role.html.twig
@@ -3,6 +3,16 @@
 
 {% block title %}{{ 'Konfiguracja ról'|trans }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item">Konfiguracja</li>
+        <li class="breadcrumb-item active" aria-current="page">Role</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 <app>
     <auth-configuration-wrapper>

--- a/app/templates/configuration/single_user.html.twig
+++ b/app/templates/configuration/single_user.html.twig
@@ -11,6 +11,19 @@
 
 {% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item">Konfiguracja</li>
+        <li class="breadcrumb-item"><a href="{{ path('security_users') }}">Użytkownicy</a></li>
+        <li class="breadcrumb-item active" aria-current="page">
+            {{ user is not null ? 'Edycja użytkownika' : 'Nowy użytkownik' }}
+        </li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
     <app>
         <auth-configuration-wrapper>

--- a/app/templates/configuration/tags.html.twig
+++ b/app/templates/configuration/tags.html.twig
@@ -3,6 +3,16 @@
 
 {% block title %}{{ 'Konfiguracja tagów'|trans }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item">Konfiguracja</li>
+        <li class="breadcrumb-item active" aria-current="page">Tagi</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
     <tags-config></tags-config>
 {% endblock %}

--- a/app/templates/configuration/users.html.twig
+++ b/app/templates/configuration/users.html.twig
@@ -3,6 +3,16 @@
 
 {% block title %}{{ 'Konfiguracja użytkowników'|trans }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item">Konfiguracja</li>
+        <li class="breadcrumb-item active" aria-current="page">Użytkownicy</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
     <users-list></users-list>
 {% endblock %}

--- a/app/templates/configuration/work_configuration.html.twig
+++ b/app/templates/configuration/work_configuration.html.twig
@@ -3,6 +3,16 @@
 
 {% block title %}{{ 'Konfiguracja produkcji'|trans }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item">Konfiguracja</li>
+        <li class="breadcrumb-item active" aria-current="page">Produkcja</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 <app>
     <production-configuration></production-configuration>

--- a/app/templates/customers/customer_single.html.twig
+++ b/app/templates/customers/customer_single.html.twig
@@ -3,6 +3,18 @@
 
 {% block title %}{{ title }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item"><a href="{{ path('customers_show') }}">Lista klientów</a></li>
+        <li class="breadcrumb-item active" aria-current="page">
+            {{ app.request.attributes.get('_route') == 'customers_new' ? 'Nowy klient' : 'Edycja klienta' }}
+        </li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 
     <div class="card shadow mb-4">

--- a/app/templates/customers/customers_show.html.twig
+++ b/app/templates/customers/customers_show.html.twig
@@ -3,6 +3,15 @@
 
 {% block title %}{{ 'Klienci'|trans }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item active" aria-current="page">Lista klientów</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 
     <div class="card shadow mb-4">

--- a/app/templates/orders/order_single.html.twig
+++ b/app/templates/orders/order_single.html.twig
@@ -2,6 +2,16 @@
 
 {% block title %}{{ title }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item"><a href="{{ path('agreements_show') }}">Lista zamówień</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Nowe zamówienie</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
     <div class="card shadow mb-4">
         <div class="card-header py-3">

--- a/app/templates/orders/order_single_edit.html.twig
+++ b/app/templates/orders/order_single_edit.html.twig
@@ -2,6 +2,16 @@
 
 {% block title %}{{ title }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item"><a href="{{ path('agreements_show') }}">Lista zamówień</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Edycja zamówienia</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
     <div class="card shadow mb-4">
         <div class="card-header py-3">

--- a/app/templates/orders/orders_show.html.twig
+++ b/app/templates/orders/orders_show.html.twig
@@ -2,6 +2,15 @@
 
 {% block title %}{{ title }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item active" aria-current="page">Lista zamówień</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 
 <orders-list

--- a/app/templates/production/production_show.html.twig
+++ b/app/templates/production/production_show.html.twig
@@ -2,6 +2,15 @@
 
 {% block title %}{{ title }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item active" aria-current="page">Harmonogram produkcji</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 
 {#<production-list#}

--- a/app/templates/products/product_single.html.twig
+++ b/app/templates/products/product_single.html.twig
@@ -3,6 +3,18 @@
 
 {% block title %}{{ title }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item"><a href="{{ path('products_show') }}">Lista produktów</a></li>
+        <li class="breadcrumb-item active" aria-current="page">
+            {{ app.request.attributes.get('_route') == 'products_new' ? 'Nowy produkt' : 'Edycja produktu' }}
+        </li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 
     <div class="card shadow mb-4">

--- a/app/templates/products/products_show.html.twig
+++ b/app/templates/products/products_show.html.twig
@@ -3,6 +3,15 @@
 
 {% block title %}{{ 'Produkty'|trans }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item active" aria-current="page">Lista produktów</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 
     <div class="card shadow mb-4">

--- a/app/templates/reports/report_differences.html.twig
+++ b/app/templates/reports/report_differences.html.twig
@@ -3,6 +3,16 @@
 
 {% block title %}{{ 'Raport rozbieżności od planu'|trans }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item">Raporty</li>
+        <li class="breadcrumb-item active" aria-current="page">Raport rozbieżności</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
     <app>
         <differences-report></differences-report>

--- a/app/templates/schedule/schedule_production.html.twig
+++ b/app/templates/schedule/schedule_production.html.twig
@@ -3,6 +3,15 @@
 
 {% block title %}{{ 'Kalendarz produkcji'|trans }}{% endblock %}
 
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ path('dashboard_show') }}" aria-label="Pulpit"><i class="fa fa-home" aria-hidden="true"></i></a></li>
+        <li class="breadcrumb-item active" aria-current="page">Kalendarz</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block body %}
 <app>
     <schedule-production></schedule-production>


### PR DESCRIPTION
Breadcrumbs appear right-aligned on a second row below the topbar menu, styled as small muted text with primary-color links and a home icon as the first item. Covers orders, customers, products, users, configuration, production, calendar, and differences report pages.