### PR TITLE
Validate attachment uploads and surface per-file errors

### DIFF
--- a/app/assets/js-vue/src/modules/agreement/components/AttachmentForm.vue
+++ b/app/assets/js-vue/src/modules/agreement/components/AttachmentForm.vue
@@ -7,7 +7,7 @@
             @vdropzone-file-added="onFileAdded"
             @vdropzone-removed-file="onFileRemoved"
             @vdropzone-queue-complete="$emit('vdropzone-queue-complete')"
-            @vdropzone-error="(file, message, xhr) => $emit('vdropzone-error', file, message, xhr)"
+            @vdropzone-error="onDropzoneError"
         />
     </div>
 </template>
@@ -24,6 +24,7 @@ export default {
     data() {
         return {
             removedIds: [],
+            errorFiles: [],
         };
     },
 
@@ -56,10 +57,14 @@ export default {
 
         processQueue(url, appendFormValues) {
             this.$refs.dropzone.setOption('url', url);
-            this.$refs.dropzone.$on('vdropzone-sending', (file, xhr, formData) => {
+            this.$refs.dropzone.$once('vdropzone-sending-multiple', (files, xhr, formData) => {
                 appendFormValues(formData);
             });
             this.$refs.dropzone.processQueue();
+        },
+
+        getErrorFiles() {
+            return this.$refs.dropzone.getFilesWithStatus('error');
         },
 
         loadExistingFiles(attachments) {
@@ -77,6 +82,26 @@ export default {
             });
         },
 
+        onDropzoneError(file, message, xhr) {
+            if (!xhr) {
+                // Lokalny błąd walidacji (za duży plik, zły typ) — brak requestu do serwera
+                this.$emit('vdropzone-file-rejected', message);
+            } else {
+                // Z odpowiedzi serwera wyciągamy komunikat per plik (uploadMultiple
+                // powoduje, że dropzone domyślnie wsadzi to samo `message` każdemu plikowi).
+                const perFileMessage = this.findPerFileMessage(file, xhr);
+                if (perFileMessage) {
+                    this.replaceErrorMessageInDom(file, perFileMessage);
+                    message = perFileMessage;
+                }
+                this.$emit('vdropzone-error', file, message, xhr);
+            }
+            if (!this.errorFiles.includes(file)) {
+                this.errorFiles.push(file);
+            }
+            this.$emit('error-state-changed', this.errorFiles.length > 0);
+        },
+
         onFileAdded() {
             this.$emit('files-changed', this.getQueuedFiles());
         },
@@ -85,7 +110,32 @@ export default {
             if (file.id) {
                 this.removedIds.push(file.id);
             }
+            const idx = this.errorFiles.indexOf(file);
+            if (idx !== -1) {
+                this.errorFiles.splice(idx, 1);
+            }
             this.$emit('files-changed', this.getQueuedFiles());
+            this.$emit('error-state-changed', this.errorFiles.length > 0);
+        },
+
+        findPerFileMessage(file, xhr) {
+            try {
+                const data = JSON.parse(xhr.responseText);
+                if (Array.isArray(data.errors)) {
+                    const match = data.errors.find(e => e.filename === file.name);
+                    return match ? match.message : null;
+                }
+            } catch (e) { /* responseText nie jest JSON-em — fallback do domyślnego message */ }
+            return null;
+        },
+
+        replaceErrorMessageInDom(file, message) {
+            if (!file.previewElement) {
+                return;
+            }
+            file.previewElement.querySelectorAll('[data-dz-errormessage]').forEach(el => {
+                el.textContent = message;
+            });
         }
     }
 };
@@ -108,6 +158,35 @@ export default {
 
         .dz-message {
             margin: 0.5rem 0;
+        }
+
+        .dz-preview {
+            // Przycisk remove wyśrodkowany horyzontalnie dla wszystkich miniatur
+            .dz-remove {
+                left: 50%;
+                transform: translateX(-50%);
+                margin-left: 0;
+            }
+
+            &.dz-error {
+                // Komunikat zawsze widoczny, nie tylko na hover
+                .dz-error-message {
+                    opacity: 1;
+                    pointer-events: none;
+                }
+
+                // Przycisk remove: góra, wyśrodkowany, na hover, z tłem dla czytelności
+                .dz-remove {
+                    z-index: 1001;
+                    top: 5px;
+                    bottom: auto;
+                    left: 50%;
+                    transform: translateX(-50%);
+                    margin-left: 0;
+                    background-color: rgba(0, 0, 0, 0.55);
+                    border-radius: 4px;
+                }
+            }
         }
     }
 }

--- a/app/assets/js-vue/src/modules/agreement/locale/en.js
+++ b/app/assets/js-vue/src/modules/agreement/locale/en.js
@@ -10,6 +10,7 @@ export default {
         'attachments': 'Attachments',
         'saveNew': 'Save order',
         'saveEdit': 'Save changes',
+        'attachmentUploadFailed': 'File upload failed. Please remove the failed files and add them again.',
     },
     'customer': {
         'sectionTitle': 'Customer',

--- a/app/assets/js-vue/src/modules/agreement/locale/pl.js
+++ b/app/assets/js-vue/src/modules/agreement/locale/pl.js
@@ -10,6 +10,7 @@ export default {
         'attachments': 'Załączniki',
         'saveNew': 'Zapisz zamówienie',
         'saveEdit': 'Zapisz zmiany',
+        'attachmentUploadFailed': 'Przesyłanie plików nie powiodło się. Usuń nieudane pliki i dodaj je ponownie.',
     },
     'customer': {
         'sectionTitle': 'Klient',

--- a/app/assets/js-vue/src/modules/agreement/view/AgreementForm.vue
+++ b/app/assets/js-vue/src/modules/agreement/view/AgreementForm.vue
@@ -63,6 +63,8 @@
                     ref="attachmentForm"
                     @vdropzone-queue-complete="onSaveSuccess"
                     @vdropzone-error="onSaveError"
+                    @vdropzone-file-rejected="onFileRejected"
+                    @error-state-changed="hasErrorFiles = $event"
                 />
             </div>
         </div>
@@ -72,7 +74,7 @@
             <button
                 class="btn btn-primary btn-lg"
                 @click="save"
-                :disabled="!canSave"
+                :disabled="!canSave || isSaving"
                 type="button"
             >
                 <i class="fa fa-check-square-o"></i>
@@ -121,6 +123,7 @@ export default {
             waiting: false,
             products: [],
             isSaving: false,
+            hasErrorFiles: false,
         };
     },
 
@@ -159,7 +162,8 @@ export default {
                 this.form.products.length > 0 &&
                 this.form.products.every(p => p.productId !== null) &&
                 this.form.products.every(p => p.requiredDate !== null) &&
-                this.isNumberValid
+                this.isNumberValid &&
+                !this.hasErrorFiles
             );
         }
     },
@@ -223,8 +227,15 @@ export default {
             };
 
             // Jeżeli są załączone pliki, request wysyła dropzone
-            if (this.$refs.attachmentForm.getQueuedFiles().length > 0) {
+            const queuedFiles = this.$refs.attachmentForm.getQueuedFiles();
+            const errorFiles  = this.$refs.attachmentForm.getErrorFiles();
+
+            if (queuedFiles.length > 0) {
                 this.$refs.attachmentForm.processQueue(url, appendFormValues);
+            } else if (errorFiles.length > 0) {
+                this.$flash.danger(this.$t('agreement.form.attachmentUploadFailed'));
+                this.isSaving = false;
+                return;
             } else {
                 const formData = new FormData();
                 appendFormValues(formData);
@@ -256,8 +267,15 @@ export default {
         },
 
         onSaveError() {
+            if (!this.isSaving) {
+                return;
+            }
             this.isSaving = false;
             this.$flash.danger(this.$t('_saveError'));
+        },
+
+        onFileRejected(message) {
+            this.$flash.danger(message);
         },
 
         loadAgreement() {
@@ -266,6 +284,7 @@ export default {
                 .then(({data}) => {
                     if (data) {
                         this.form.customerId = data.customerId;
+                        this.isNumberValid = true;
                         this.form.orderNumber = this.initialOrderNumber = data.orderNumber;
 
                         if (data.products && data.products.length > 0) {

--- a/app/src/Module/Agreement/Controller/AgreementController.php
+++ b/app/src/Module/Agreement/Controller/AgreementController.php
@@ -8,6 +8,7 @@ use App\Module\Agreement\Command\UpdateAgreementCommand;
 use App\Service\UploaderHelper;
 use App\System\CommandBus;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -30,6 +31,10 @@ class AgreementController extends AbstractController
     #[Route('/save', name: 'orders_add', options: ['expose' => true], methods: ['POST'])]
     public function save(Request $request): JsonResponse
     {
+        if ($errorResponse = $this->validatePostSize($request)) {
+            return $errorResponse;
+        }
+
         $data = $request->request->all();
 
         // Parsowanie products jeśli przyszły jako JSON string
@@ -71,6 +76,10 @@ class AgreementController extends AbstractController
                 $rawFiles = [$rawFiles];
             }
             $attachments = $this->uploaderHelper->getUploadedFiles($rawFiles);
+
+            if ($errorResponse = $this->validateAttachments($attachments)) {
+                return $errorResponse;
+            }
         }
 
         try {
@@ -104,6 +113,10 @@ class AgreementController extends AbstractController
     #[Route('/patch/{agreement}', name: 'orders_patch', options: ['expose' => true], methods: ['POST'])]
     public function update(Agreement $agreement, Request $request): JsonResponse
     {
+        if ($errorResponse = $this->validatePostSize($request)) {
+            return $errorResponse;
+        }
+
         $data = $request->request->all();
 
         // Parsowanie products jeśli przyszły jako JSON string
@@ -148,6 +161,10 @@ class AgreementController extends AbstractController
                 $rawFiles = [$rawFiles];
             }
             $attachments = $this->uploaderHelper->getUploadedFiles($rawFiles);
+
+            if ($errorResponse = $this->validateAttachments($attachments)) {
+                return $errorResponse;
+            }
         }
 
         try {
@@ -175,5 +192,78 @@ class AgreementController extends AbstractController
                 Response::HTTP_INTERNAL_SERVER_ERROR
             );
         }
+    }
+
+    private function validatePostSize(Request $request): ?JsonResponse
+    {
+        $maxBytes = $this->iniSizeToBytes((string) ini_get('post_max_size'));
+        if ($maxBytes <= 0) {
+            return null;
+        }
+
+        $contentLength = (int) $request->headers->get('Content-Length', '0');
+        if ($contentLength <= 0 || $contentLength <= $maxBytes) {
+            return null;
+        }
+
+        return $this->json(
+            [
+                'error' => sprintf(
+                    'Request size exceeds server limit (max %s).',
+                    ini_get('post_max_size'),
+                ),
+            ],
+            Response::HTTP_REQUEST_ENTITY_TOO_LARGE,
+        );
+    }
+
+    private function iniSizeToBytes(string $value): int
+    {
+        $value = trim($value);
+        if ('' === $value) {
+            return 0;
+        }
+
+        $unit = strtolower($value[strlen($value) - 1]);
+        $number = (int) $value;
+
+        return match ($unit) {
+            'g' => $number * 1024 ** 3,
+            'm' => $number * 1024 ** 2,
+            'k' => $number * 1024,
+            default => (int) $value,
+        };
+    }
+
+    /**
+     * @param UploadedFile[] $attachments
+     */
+    private function validateAttachments(array $attachments): ?JsonResponse
+    {
+        $errors = [];
+        foreach ($attachments as $attachment) {
+            if (UPLOAD_ERR_OK === $attachment->getError()) {
+                continue;
+            }
+
+            $errors[] = [
+                'filename' => $attachment->getClientOriginalName(),
+                'message' => $attachment->getErrorMessage(),
+            ];
+        }
+
+        if (empty($errors)) {
+            return null;
+        }
+
+        $summary = implode(', ', array_map(static fn (array $e): string => $e['filename'], $errors));
+
+        return $this->json(
+            [
+                'error' => sprintf('Rejected attachments: %s', $summary),
+                'errors' => $errors,
+            ],
+            Response::HTTP_BAD_REQUEST,
+        );
     }
 }


### PR DESCRIPTION
Reject oversized uploads in AgreementController (post_max_size + per-file upload error checks) returning structured errors. Frontend maps the response to per-file messages in the dropzone preview, disables Save Order while any attachment is in an error state, and deduplicates the flash message via an isSaving guard.