### PR TITLE
Add CLI to rebuild production status-change logs from StatusLog history

### DIFF
--- a/app/src/Module/ActivityLog/CLI/MigrateStatusLogsCommand.php
+++ b/app/src/Module/ActivityLog/CLI/MigrateStatusLogsCommand.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Module\ActivityLog\CLI;
+
+use App\Entity\StatusLog;
+use App\Entity\User;
+use App\Module\ActivityLog\Entity\ActivityLog;
+use App\Module\ActivityLog\Entity\LogField;
+use App\Module\ActivityLog\ValueObject\LogLevel;
+use App\Module\ActivityLog\ValueObject\LogPriority;
+use App\Module\Agreement\ActivityLog\AgreementActivityLogType;
+use App\Module\Production\ValueObject\DepartmentEnum;
+use App\Module\Production\ValueObject\ProductionTaskStatus;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Rebuilds production status-change activity logs from the legacy StatusLog history.
+ *
+ * StatusLog holds the full per-production status history, so for every change we can derive both the
+ * previous (old) and the current (new) status — fixing logs that lacked the old value. The command is
+ * idempotent: it deletes all existing `agreement_line.production_status_changed` logs and regenerates
+ * them from StatusLog (the single source of truth for those logs).
+ *
+ * ActivityLog entities are built directly (not via AddActivityLogCommand) on purpose: a historical
+ * backfill must not emit ActivityLogWasAddedEvent, and direct construction allows batching and setting
+ * a historical createdAt + arbitrary author.
+ */
+#[AsCommand(
+    name: 'app:activity-log:migrate-status-logs',
+    description: 'Rebuilds production status-change activity logs from legacy StatusLog history.',
+)]
+class MigrateStatusLogsCommand extends Command
+{
+    private const NO_STATUS = '—';
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report what would change, without touching the database')
+            ->addOption('batch-size', null, InputOption::VALUE_OPTIONAL, 'How many logs to persist per flush', 100);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $isDryRun = (bool) $input->getOption('dry-run');
+        $batchSize = max(1, (int) $input->getOption('batch-size'));
+        $type = AgreementActivityLogType::AGREEMENT_LINE_PRODUCTION_STATUS_CHANGED->value;
+
+        $io->title(sprintf('Migracja StatusLog → ActivityLog (%s)', $isDryRun ? 'DRY RUN' : 'APPLY'));
+
+        $existingCount = $this->countExisting($type);
+        $rows = $this->fetchStatusLogRows();
+        $changes = $this->buildChanges($rows);
+
+        $io->definitionList(
+            ['Istniejące logi tego typu (do usunięcia)' => $existingCount],
+            ['Wpisy StatusLog' => count($rows)],
+            ['Realne zmiany do utworzenia (po pominięciu no-opów)' => count($changes)],
+        );
+
+        if ($isDryRun) {
+            $io->success('DRY RUN — baza danych nie została zmieniona.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->deleteExisting($type);
+
+        $progress = $io->createProgressBar(count($changes));
+        $progress->start();
+
+        $batch = [];
+        foreach ($changes as $change) {
+            $log = $this->buildLog($type, $change);
+            $this->em->persist($log);
+            $batch[] = [$log, $change['createdAt']];
+
+            if (count($batch) >= $batchSize) {
+                $this->flushBatch($batch);
+                $batch = [];
+            }
+
+            $progress->advance();
+        }
+
+        if ($batch !== []) {
+            $this->flushBatch($batch);
+        }
+
+        $progress->finish();
+        $io->newLine(2);
+        $io->success(sprintf('Usunięto %d, utworzono %d logów „%s".', $existingCount, count($changes), $type));
+
+        return Command::SUCCESS;
+    }
+
+    private function countExisting(string $type): int
+    {
+        return (int) $this->em
+            ->createQuery(sprintf('SELECT COUNT(al.id) FROM %s al WHERE al.type = :type', ActivityLog::class))
+            ->setParameter('type', $type)
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * @return list<array<string, mixed>> scalar rows ordered by production, then chronologically
+     */
+    private function fetchStatusLogRows(): array
+    {
+        return $this->em->createQueryBuilder()
+            ->select(
+                'sl.id AS statusLogId',
+                'sl.currentStatus AS currentStatus',
+                'sl.createdAt AS createdAt',
+                'IDENTITY(sl.user) AS userId',
+                'p.id AS productionId',
+                'p.departmentSlug AS departmentSlug',
+                'line.id AS lineId',
+                'agr.id AS agreementId',
+            )
+            ->from(StatusLog::class, 'sl')
+            ->innerJoin('sl.production', 'p')
+            ->innerJoin('p.agreementLine', 'line')
+            ->innerJoin('line.Agreement', 'agr')
+            ->orderBy('p.id', 'ASC')
+            ->addOrderBy('sl.createdAt', 'ASC')
+            ->addOrderBy('sl.id', 'ASC')
+            ->getQuery()
+            ->getScalarResult();
+    }
+
+    /**
+     * Walks the per-production history, attaching the previous status as "old" and skipping no-op rows
+     * (where the status did not actually change), mirroring UpdateStatusCommandHandler's "skip unchanged".
+     *
+     * @param  list<array<string, mixed>>  $rows
+     * @return list<array{oldStatus: int|null, newStatus: int, departmentSlug: string, lineId: int, agreementId: int, userId: int|null, createdAt: \DateTimeInterface}>
+     */
+    private function buildChanges(array $rows): array
+    {
+        $changes = [];
+        $prevProductionId = null;
+        $prevStatus = null;
+
+        foreach ($rows as $row) {
+            $productionId = (int) $row['productionId'];
+            $currentStatus = (int) $row['currentStatus'];
+
+            if ($productionId !== $prevProductionId) {
+                $prevProductionId = $productionId;
+                $prevStatus = null;
+            }
+
+            if ($prevStatus !== null && $prevStatus === $currentStatus) {
+                continue;
+            }
+
+            $changes[] = [
+                'oldStatus' => $prevStatus,
+                'newStatus' => $currentStatus,
+                'departmentSlug' => (string) $row['departmentSlug'],
+                'lineId' => (int) $row['lineId'],
+                'agreementId' => (int) $row['agreementId'],
+                'userId' => $row['userId'] !== null ? (int) $row['userId'] : null,
+                'createdAt' => new \DateTimeImmutable((string) $row['createdAt']),
+            ];
+
+            $prevStatus = $currentStatus;
+        }
+
+        return $changes;
+    }
+
+    /**
+     * @param array{oldStatus: int|null, newStatus: int, departmentSlug: string, lineId: int, agreementId: int, userId: int|null, createdAt: \DateTimeInterface} $change
+     */
+    private function buildLog(string $type, array $change): ActivityLog
+    {
+        $department = DepartmentEnum::tryFrom($change['departmentSlug']);
+        $oldStatus = $change['oldStatus'] !== null ? ProductionTaskStatus::tryFrom($change['oldStatus']) : null;
+        $newStatus = ProductionTaskStatus::tryFrom($change['newStatus']);
+
+        /** @var User|null $user */
+        $user = $change['userId'] !== null ? $this->em->getReference(User::class, $change['userId']) : null;
+
+        $log = new ActivityLog(
+            $type,
+            'activity_log.' . $type,
+            $user,
+            LogLevel::INFO,
+            LogPriority::normal,
+            [
+                'departmentName' => $department?->getName() ?? $change['departmentSlug'],
+                'oldStatusName' => $oldStatus?->getName() ?? self::NO_STATUS,
+                'newStatusName' => $newStatus?->getName() ?? (string) $change['newStatus'],
+            ],
+        );
+
+        $log->addLogField('id', (string) $change['lineId']);
+        $log->addLogField('agreementId', (string) $change['agreementId']);
+
+        return $log;
+    }
+
+    /**
+     * Persists the batch, then overrides createdAt (Gedmo forces "now" on insert, so it must be set
+     * after the first flush) and frees memory.
+     *
+     * @param list<array{0: ActivityLog, 1: \DateTimeInterface}> $batch
+     */
+    private function flushBatch(array $batch): void
+    {
+        $this->em->flush();
+
+        foreach ($batch as [$log, $createdAt]) {
+            $log->setCreatedAt($createdAt);
+        }
+
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    private function deleteExisting(string $type): void
+    {
+        $this->em
+            ->createQuery(sprintf(
+                'DELETE FROM %s lf WHERE IDENTITY(lf.log) IN (SELECT al.id FROM %s al WHERE al.type = :type)',
+                LogField::class,
+                ActivityLog::class,
+            ))
+            ->setParameter('type', $type)
+            ->execute();
+
+        $this->em
+            ->createQuery(sprintf('DELETE FROM %s al WHERE al.type = :type', ActivityLog::class))
+            ->setParameter('type', $type)
+            ->execute();
+    }
+}

--- a/app/tests/End2End/Modules/ActivityLog/MigrateStatusLogsCommandTest.php
+++ b/app/tests/End2End/Modules/ActivityLog/MigrateStatusLogsCommandTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Tests\End2End\Modules\ActivityLog;
+
+use App\Entity\Definitions\TaskTypes;
+use App\Entity\Production;
+use App\Entity\StatusLog;
+use App\Module\ActivityLog\Entity\ActivityLog;
+use App\Module\ActivityLog\Repository\ActivityLogRepository;
+use App\Module\ActivityLog\ValueObject\LogLevel;
+use App\Module\ActivityLog\ValueObject\LogPriority;
+use App\System\Test\ApiTestCase;
+use App\Tests\Utilities\Factory\AgreementLineChainFactory;
+use App\Tests\Utilities\Factory\EntityFactory;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class MigrateStatusLogsCommandTest extends ApiTestCase
+{
+    private const TYPE = 'agreement_line.production_status_changed';
+
+    private ActivityLogRepository $activityLogRepository;
+    private EntityFactory $factory;
+    private AgreementLineChainFactory $chainFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->getManager()->beginTransaction();
+        $this->activityLogRepository = $this->get(ActivityLogRepository::class);
+        $this->factory = new EntityFactory($this->getManager());
+        $this->chainFactory = new AgreementLineChainFactory($this->factory);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->getManager()->rollback();
+        parent::tearDown();
+    }
+
+    public function testShouldRebuildLogsFromStatusLogHistory(): void
+    {
+        // Given — a production with three real status changes recorded in StatusLog
+        $user = $this->createUser();
+        $line = $this->chainFactory->make();
+        $agreementId = $line->getAgreement()->getId();
+
+        $production = $this->factory->make(Production::class, [
+            'agreementLine' => $line,
+            'departmentSlug' => TaskTypes::TYPE_DEFAULT_SLUG_GLUING,
+            'status' => TaskTypes::TYPE_DEFAULT_STATUS_COMPLETED,
+            'isGhost' => false,
+        ]);
+
+        $sl1 = $this->factory->make(StatusLog::class, ['production' => $production, 'currentStatus' => TaskTypes::TYPE_DEFAULT_STATUS_AWAITS, 'user' => $user]);
+        $sl2 = $this->factory->make(StatusLog::class, ['production' => $production, 'currentStatus' => TaskTypes::TYPE_DEFAULT_STATUS_PENDING, 'user' => $user]);
+        $sl3 = $this->factory->make(StatusLog::class, ['production' => $production, 'currentStatus' => TaskTypes::TYPE_DEFAULT_STATUS_COMPLETED, 'user' => $user]);
+        $this->getManager()->flush();
+
+        // Force distinct historical createdAt (Gedmo sets "now" on insert, so override after the first flush)
+        $sl1->setCreatedAt(new \DateTime('2026-05-01 08:00:00'));
+        $sl2->setCreatedAt(new \DateTime('2026-05-02 09:00:00'));
+        $sl3->setCreatedAt(new \DateTime('2026-05-03 10:00:00'));
+        $this->getManager()->flush();
+
+        // And — a stale log of this type that must be overwritten (deleted) by the rebuild
+        $stale = new ActivityLog(self::TYPE, 'activity_log.' . self::TYPE, $user, LogLevel::INFO, LogPriority::normal, [
+            'departmentName' => 'Klejenie',
+            'oldStatusName' => self::staleMarker(),
+            'newStatusName' => self::staleMarker(),
+        ]);
+        $stale->addLogField('id', '999999');
+        $stale->addLogField('agreementId', (string) $agreementId);
+        $this->getManager()->persist($stale);
+        $this->getManager()->flush();
+
+        $lineId = $line->getId();
+        $userId = $user->getId();
+        $this->getManager()->clear();
+
+        // When
+        $tester = $this->runMigration([]);
+
+        // Then — the command rebuilds the whole table, so scope assertions to our own line.
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $allLogs = $this->activityLogRepository->findBy(['type' => self::TYPE], ['createdAt' => 'ASC']);
+
+        // Stale log (a non-existent line) is gone — it has no StatusLog to be rebuilt from
+        $staleLeft = array_filter($allLogs, fn (ActivityLog $log) => $this->fieldValue($log, 'id') === '999999');
+        $this->assertCount(0, $staleLeft, 'Stale log of this type was overwritten/removed');
+
+        // Exactly one log per real status change of our production, chronological old → new chain
+        $logs = array_values(array_filter($allLogs, fn (ActivityLog $log) => $this->fieldValue($log, 'id') === (string) $lineId));
+        $this->assertCount(3, $logs);
+        $this->assertChange($logs[0], '—', 'Oczekuje', '2026-05-01 08:00:00', $lineId, $agreementId, $userId);
+        $this->assertChange($logs[1], 'Oczekuje', 'W trakcie', '2026-05-02 09:00:00', $lineId, $agreementId, $userId);
+        $this->assertChange($logs[2], 'W trakcie', 'Zakończone', '2026-05-03 10:00:00', $lineId, $agreementId, $userId);
+    }
+
+    public function testDryRunMakesNoChanges(): void
+    {
+        // Given — one production with two status changes and a stale log
+        $user = $this->createUser();
+        $line = $this->chainFactory->make();
+        $production = $this->factory->make(Production::class, [
+            'agreementLine' => $line,
+            'departmentSlug' => TaskTypes::TYPE_DEFAULT_SLUG_GLUING,
+            'status' => TaskTypes::TYPE_DEFAULT_STATUS_PENDING,
+            'isGhost' => false,
+        ]);
+        $this->factory->make(StatusLog::class, ['production' => $production, 'currentStatus' => TaskTypes::TYPE_DEFAULT_STATUS_AWAITS, 'user' => $user]);
+        $this->factory->make(StatusLog::class, ['production' => $production, 'currentStatus' => TaskTypes::TYPE_DEFAULT_STATUS_PENDING, 'user' => $user]);
+
+        $stale = new ActivityLog(self::TYPE, 'activity_log.' . self::TYPE, $user, LogLevel::INFO, LogPriority::normal, [
+            'departmentName' => 'Klejenie',
+            'oldStatusName' => self::staleMarker(),
+            'newStatusName' => self::staleMarker(),
+        ]);
+        $stale->addLogField('id', '999999');
+        $this->getManager()->persist($stale);
+        $this->getManager()->flush();
+        $this->getManager()->clear();
+
+        // When
+        $tester = $this->runMigration(['--dry-run' => true]);
+
+        // Then — the only log of this type is still the untouched stale one
+        $this->assertSame(0, $tester->getStatusCode());
+        $logs = $this->activityLogRepository->findBy(['type' => self::TYPE]);
+        $this->assertCount(1, $logs);
+        $this->assertSame(self::staleMarker(), $logs[0]->getContentParams()['newStatusName'] ?? null);
+        $this->assertStringContainsString('DRY RUN', $tester->getDisplay());
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function runMigration(array $input): CommandTester
+    {
+        $this->getManager(); // ensure the kernel is booted
+        $application = new Application(self::$kernel);
+        $command = $application->find('app:activity-log:migrate-status-logs');
+
+        $tester = new CommandTester($command);
+        $tester->execute($input);
+
+        return $tester;
+    }
+
+    private function assertChange(
+        ActivityLog $log,
+        string $expectedOld,
+        string $expectedNew,
+        string $expectedCreatedAt,
+        int $lineId,
+        int $agreementId,
+        int $userId,
+    ): void {
+        $params = $log->getContentParams();
+        $this->assertSame('Klejenie', $params['departmentName']);
+        $this->assertSame($expectedOld, $params['oldStatusName']);
+        $this->assertSame($expectedNew, $params['newStatusName']);
+        $this->assertSame($expectedCreatedAt, $log->getCreatedAt()->format('Y-m-d H:i:s'));
+        $this->assertSame($userId, $log->getUser()?->getId());
+
+        $fields = [];
+        foreach ($log->getLogFields() as $field) {
+            $fields[$field->getName()] = $field->getValue();
+        }
+        $this->assertSame((string) $lineId, $fields['id']);
+        $this->assertSame((string) $agreementId, $fields['agreementId']);
+    }
+
+    private function fieldValue(ActivityLog $log, string $name): ?string
+    {
+        foreach ($log->getLogFields() as $field) {
+            if ($field->getName() === $name) {
+                return $field->getValue();
+            }
+        }
+
+        return null;
+    }
+
+    private static function staleMarker(): string
+    {
+        return 'STALE-TO-BE-DELETED';
+    }
+}


### PR DESCRIPTION
`app:activity-log:migrate-status-logs` deletes all existing `agreement_line.production_status_changed` activity logs and regenerates them from the legacy StatusLog history (the single source of truth for those logs). Walking each production's history chronologically lets it fill the previous status as the "old" value — fixing logs created before the old status was captured. No-op changes are skipped.

Entities are built directly (not via AddActivityLogCommand) so a historical backfill does not emit ActivityLogWasAddedEvent, can be batched, and can set a historical createdAt and arbitrary author. Idempotent and re-runnable; supports --dry-run and --batch-size.