### PR TITLE
Add `activeDepartment` support to production workflows and status han…

### DIFF
--- a/app/assets/js-vue/src/components/orders/single/ProductionWidget.vue
+++ b/app/assets/js-vue/src/components/orders/single/ProductionWidget.vue
@@ -5,7 +5,7 @@
             {{ $t('dashboard.ghostOrderBanner') }}
         </div>
 
-        <b-tabs pills card vertical nav-wrapper-class="production-tab-panel">
+        <b-tabs v-model="activeTabIndex" pills card vertical nav-wrapper-class="production-tab-panel">
             <b-tab
                 v-for="tab in tabs"
                 :key="tab.id"
@@ -42,6 +42,14 @@
         name: "ProductionWidget",
         mixins: [proxyValue],
         components: {TagsWidget, DatePicker, ConfirmationModal, TaskContent },
+        props: {
+            activeDepartment: { type: String, default: null },
+        },
+        data() {
+            return {
+                activeTabIndex: 0,
+            }
+        },
         computed: {
             tabs() {
                 const systemTasks = [];
@@ -92,12 +100,32 @@
                 return this.proxyData.tasks.some(task => task.isGhost)
             }
         },
+        watch: {
+            tabs: {
+                immediate: true,
+                handler() {
+                    this.applyActiveDepartment()
+                }
+            },
+            activeDepartment() {
+                this.applyActiveDepartment()
+            }
+        },
         methods: {
             getStatusStyle(statusId) {
                 return helpers.getStatusStyle(statusId)
             },
             handleDelete(id) {
                 this.proxyData.tasks = this.proxyData.tasks.filter(task => task.id !== id);
+            },
+            applyActiveDepartment() {
+                if (!this.activeDepartment) {
+                    return
+                }
+                const index = this.tabs.findIndex(tab => tab.slug === this.activeDepartment)
+                if (index >= 0) {
+                    this.activeTabIndex = index
+                }
             },
         }
     }

--- a/app/assets/js-vue/src/components/orders/single/SingleOrder.vue
+++ b/app/assets/js-vue/src/components/orders/single/SingleOrder.vue
@@ -13,7 +13,7 @@
         <div class="row">
             <div class="col-12 col-lg-8">
                 <collapsible-card :title="$t('orders.production')" :locked="locked" v-if="orderData.productions.tasks && orderData.productions.tasks.length !== 0">
-                    <production-widget v-model="orderData.productions"/>
+                    <production-widget v-model="orderData.productions" :active-department="activeDepartment"/>
                 </collapsible-card>
 
                 <collapsible-card :title="$t('orders.orderProcessing')" :locked="locked">
@@ -104,7 +104,7 @@
             CollapsibleCard, ProductionWidget, DetailsWidget, ProductWidget, AttachmentsWidget, AgreementWidget,
             Sidebar, FactorsView, TasksView, ActivityLogList,
         },
-        props: ['lineId', 'taskStatuses'],
+        props: ['lineId', 'taskStatuses', 'activeDepartment'],
 
         data() {
             return {

--- a/app/assets/js-vue/src/modules/agreement/components/OrderPanelDrawer.vue
+++ b/app/assets/js-vue/src/modules/agreement/components/OrderPanelDrawer.vue
@@ -14,6 +14,7 @@
                     :key="lineId"
                     :line-id="lineId"
                     :task-statuses="taskStatuses"
+                    :active-department="activeDepartment"
                     @saved="onSaved"
                     @dirty-change="onDirtyChange"
                 />
@@ -43,6 +44,7 @@ export default {
     props: {
         value: { type: Boolean, default: false },
         lineId: { type: Number, required: true },
+        activeDepartment: { type: String, default: null },
     },
 
     data: () => ({

--- a/app/assets/js-vue/src/modules/schedule/components/ResourceCalendar/utils/gridHelpers.js
+++ b/app/assets/js-vue/src/modules/schedule/components/ResourceCalendar/utils/gridHelpers.js
@@ -22,15 +22,17 @@ export function eventPositionStyle(event) {
   }
 }
 
+// Keyed by production task status (ProductionTaskStatus)
 export const STATUS_COLORS = {
-  pending:     { bg: '#fff3cd', border: '#ffc107', text: '#856404' },
-  in_progress: { bg: '#cff4fc', border: '#0dcaf0', text: '#055160' },
-  completed:   { bg: '#d1e7dd', border: '#198754', text: '#0a3622' },
-  cancelled:   { bg: '#f8d7da', border: '#dc3545', text: '#58151c' }
+  awaits:         { bg: '#fff3cd', border: '#ffc107', text: '#856404' },
+  started:        { bg: '#ffe5d0', border: '#fd7e14', text: '#7a3d00' },
+  in_progress:    { bg: '#cff4fc', border: '#0dcaf0', text: '#055160' },
+  completed:      { bg: '#d1e7dd', border: '#198754', text: '#0a3622' },
+  not_applicable: { bg: '#e2e3e5', border: '#6c757d', text: '#41464b' }
 }
 
 export function eventColors(event) {
-  const status = STATUS_COLORS[event.orderStatus] || STATUS_COLORS.pending
+  const status = STATUS_COLORS[event.orderStatus] || STATUS_COLORS.awaits
   return {
     background: event.color || status.bg,
     borderColor: status.border,

--- a/app/assets/js-vue/src/modules/schedule/locale/en.js
+++ b/app/assets/js-vue/src/modules/schedule/locale/en.js
@@ -13,10 +13,11 @@ export default {
     },
     'showGhost': 'Show forecast',
     'status': {
-        'pending': 'Pending',
+        'awaits': 'Awaiting',
+        'started': 'Started',
         'in_progress': 'In progress',
         'completed': 'Completed',
-        'cancelled': 'Cancelled',
+        'not_applicable': 'Not applicable',
     },
     'loadError': 'Failed to load calendar data',
     'saved': 'Schedule updated',

--- a/app/assets/js-vue/src/modules/schedule/locale/pl.js
+++ b/app/assets/js-vue/src/modules/schedule/locale/pl.js
@@ -13,10 +13,11 @@ export default {
     },
     'showGhost': 'Pokaż prognozę',
     'status': {
-        'pending': 'Oczekujące',
+        'awaits': 'Oczekujące',
+        'started': 'Rozpoczęte',
         'in_progress': 'W trakcie',
         'completed': 'Zakończone',
-        'cancelled': 'Anulowane',
+        'not_applicable': 'Nie dotyczy',
     },
     'loadError': 'Nie udało się załadować danych kalendarza',
     'saved': 'Zapisano zmianę terminu',

--- a/app/assets/js-vue/src/modules/schedule/views/CalendarTasks.vue
+++ b/app/assets/js-vue/src/modules/schedule/views/CalendarTasks.vue
@@ -6,8 +6,8 @@ import moment from 'moment'
 import { fetchProductionResources, updateProductionDates } from "@/modules/schedule/repository/scheduleRepository";
 import { STATUS_COLORS } from "@/modules/schedule/components/ResourceCalendar/utils/gridHelpers";
 
-const STATUS_OPTIONS = ['pending', 'in_progress', 'completed', 'cancelled']
-const EDITABLE_STATUSES = ['pending', 'in_progress']
+const STATUS_OPTIONS = ['awaits', 'started', 'in_progress', 'completed', 'not_applicable']
+const EDITABLE_STATUSES = ['awaits', 'started', 'in_progress']
 
 export default {
     name: "CalendarTasks",
@@ -32,6 +32,7 @@ export default {
             },
             panelLineId: null,
             panelOpen: false,
+            panelDepartment: null,
         }
     },
 
@@ -141,6 +142,7 @@ export default {
 
         onEventClick(event) {
             this.panelLineId = event.agreementLineId
+            this.panelDepartment = event.resourceId
             this.panelOpen = false
             this.$nextTick(() => {
                 this.panelOpen = true
@@ -276,6 +278,7 @@ export default {
             :key="panelLineId"
             v-model="panelOpen"
             :line-id="panelLineId"
+            :active-department="panelDepartment"
             @saved="onPanelSaved"
         />
     </div>

--- a/app/src/Module/Reports/Schedule/Service/ScheduleProductionResourcesService.php
+++ b/app/src/Module/Reports/Schedule/Service/ScheduleProductionResourcesService.php
@@ -3,11 +3,11 @@
 namespace App\Module\Reports\Schedule\Service;
 
 use App\Entity\AgreementLine;
-use App\Entity\Definitions\TaskTypes;
 use App\Module\Agreement\ReadModel\AgreementLineRM;
 use App\Module\Agreement\ReadModel\ProductionRM;
 use App\Module\Agreement\Repository\AgreementLineRMRepository;
 use App\Module\Production\ValueObject\DepartmentEnum;
+use App\Module\Production\ValueObject\ProductionTaskStatus;
 use App\Module\Reports\Schedule\DTO\ScheduleEventDTO;
 use App\Module\Reports\Schedule\DTO\ScheduleResourceDTO;
 use Symfony\Component\Security\Core\Security;
@@ -169,13 +169,20 @@ class ScheduleProductionResourcesService
         );
     }
 
+    /**
+     * Maps the raw production task status to a stable frontend key matching
+     * ProductionTaskStatus (5 values), used by the calendar status filter and colours.
+     */
     private function mapStatus(?string $status): string
     {
-        return match ((string) $status) {
-            (string) TaskTypes::TYPE_DEFAULT_STATUS_STARTED => 'in_progress',
-            (string) TaskTypes::TYPE_DEFAULT_STATUS_COMPLETED => 'completed',
-            (string) TaskTypes::TYPE_DEFAULT_STATUS_NOT_APPLICABLE => 'cancelled',
-            default => 'pending',
+        $taskStatus = ProductionTaskStatus::tryFrom((int) $status) ?? ProductionTaskStatus::AWAITS;
+
+        return match ($taskStatus) {
+            ProductionTaskStatus::AWAITS => 'awaits',
+            ProductionTaskStatus::STARTED => 'started',
+            ProductionTaskStatus::IN_PROGRESS => 'in_progress',
+            ProductionTaskStatus::COMPLETED => 'completed',
+            ProductionTaskStatus::NOT_APPLICABLE => 'not_applicable',
         };
     }
 }

--- a/app/tests/End2End/Modules/Reports/Schedule/ScheduleProductionResourcesControllerTest.php
+++ b/app/tests/End2End/Modules/Reports/Schedule/ScheduleProductionResourcesControllerTest.php
@@ -75,7 +75,7 @@ class ScheduleProductionResourcesControllerTest extends BaseScheduleReportsTestC
         $this->assertCount(1, $content['events']);
         $this->assertSame('dpt01', $content['events'][0]['resourceId']);
         $this->assertSame('prod-5001', $content['events'][0]['id']);
-        $this->assertSame('in_progress', $content['events'][0]['orderStatus']);
+        $this->assertSame('started', $content['events'][0]['orderStatus']);
         $this->assertSame('AL-1001', $content['events'][0]['orderName']);
         $this->assertSame(1001, $content['events'][0]['agreementLineId']);
     }


### PR DESCRIPTION
…dling

- Pass `activeDepartment` across components (`CalendarTasks`, `OrderPanelDrawer`, `SingleOrder`, `ProductionWidget`) to synchronize context.
- Update `STATUS_OPTIONS`, `EDITABLE_STATUSES`, and localization files for renamed task