### PR TITLE
fix(reports): deterministyczna kolejność list details (ORDER BY agree…

### DIFF
--- a/app/src/Module/Agreement/Repository/AgreementLineRMRepository.php
+++ b/app/src/Module/Agreement/Repository/AgreementLineRMRepository.php
@@ -111,7 +111,7 @@ class AgreementLineRMRepository extends ServiceEntityRepository implements Agree
                 ->setParameter('end', \DateTime::createFromInterface($end)->setTime(23, 59, 59));
         }
 
-        return $qb->getQuery()->getResult();
+        return $qb->orderBy('l.agreementLineId', 'ASC')->getQuery()->getResult();
     }
 
     /**
@@ -143,7 +143,7 @@ class AgreementLineRMRepository extends ServiceEntityRepository implements Agree
             }
         }
 
-        return $qb->getQuery()->getResult();
+        return $qb->orderBy('l.agreementLineId', 'ASC')->getQuery()->getResult();
     }
 
     public function search(?array $criteria)


### PR DESCRIPTION
…mentLineId)

Endpointy production-pending-details / production-finished-details zwracały linie bez jawnego ORDER BY (kolejność skanu agreement_line_rm), przez co lista różniła się kolejnością od starego zapytania encjowego (sterowanego skanem agreement_line po PK). Zbiór i sumy były identyczne — tylko porządek wierszy się rozjeżdżał. Dodano ORDER BY agreementLineId ASC = kolejność tworzenia linii.