### PR TITLE
fix(sidebar): pomiar wysokości contentu od razu po otwarciu, bez prze…

### DIFF
--- a/app/assets/js-vue/src/components/base/Sidebar.vue
+++ b/app/assets/js-vue/src/components/base/Sidebar.vue
@@ -109,6 +109,20 @@ export default defineComponent({
                 }
             },
             immediate: true
+        },
+
+        bSidebarVisible(val) {
+            if (!val) {
+                return
+            }
+            // wysokość kontenera nie zależy od animacji wysuwania (translateX),
+            // więc można ją zmierzyć od razu, nie czekając na @shown
+            this.$nextTick(() => {
+                const height = this.calcContentHeight()
+                if (height) {
+                    this.contentHeight = height
+                }
+            })
         }
     },
     beforeUnmount() {
@@ -143,6 +157,9 @@ export default defineComponent({
             if (!this.locked) {
                 lockBodyScroll()
                 this.locked = true
+            }
+            if (this.contentHeight === null) {
+                this.contentHeight = this.calcContentHeight() || 0
             }
         },
 
@@ -196,7 +213,8 @@ export default defineComponent({
 
             <template #default>
                 <div ref="content" class="h-100">
-                    <slot name="sidebar-content"
+                    <slot v-if="contentHeight !== null"
+                          name="sidebar-content"
                           :open="openSidebar"
                           :close="closeSidebar"
                           :height="contentHeight"


### PR DESCRIPTION
…skoku z 350px

Wysokość była mierzona dopiero w @shown (po animacji wysuwania), przez co content renderował się chwilowo z domyślną wysokością. Pomiar odbywa się teraz w nextTick po wstawieniu sidebara do DOM, a slot renderuje się dopiero po zmierzeniu wysokości.