### PR TITLE
Rename "Kalendarz zadań" to "Kalendarz produkcji" and rework calendar…

### DIFF
--- a/app/src/Module/Reports/Schedule/Controller/ViewController.php
+++ b/app/src/Module/Reports/Schedule/Controller/ViewController.php
@@ -9,14 +9,14 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class ViewController extends BaseController
 {
-    #[Route(path: '/view/production/v2', name: 'schedule_production_v2', methods: ['GET'])]
+    #[Route(path: '/view/production', name: 'schedule_production_v2', methods: ['GET'])]
     #[IsGranted('reports.calendar_tasks')]
     public function calendarV2(): Response
     {
         return $this->render('schedule/schedule_production_v2.html.twig');
     }
 
-    #[Route(path: '/view/production', name: 'schedule_production', methods: ['GET'])]
+    #[Route(path: '/view/production/basic', name: 'schedule_production', methods: ['GET'])]
     #[IsGranted('reports.calendar_general')]
     public function index(): Response
     {

--- a/app/templates/_sidebar.html.twig
+++ b/app/templates/_sidebar.html.twig
@@ -111,18 +111,18 @@
                 :title="'{{ 'Kalendarze'|trans }}'"
             >
                 <div class="submenu collapse-inner">
+                    {% if is_granted('reports.calendar_tasks') %}
+                        <a href="{{ path('schedule_production_v2') }}"
+                           class="{% if active == 'schedule_production_v2' %}active{% endif %}"
+                        >
+                            {{ 'Kalendarz produkcji'|trans }}
+                        </a>
+                    {% endif %}
                     {% if is_granted('reports.calendar_general') %}
                         <a href="{{ path('schedule_production') }}"
                            class="{% if active == 'schedule_production' %}active{% endif %}"
                         >
                             {{ 'Kalendarz ogólny'|trans }}
-                        </a>
-                    {% endif %}
-                    {% if is_granted('reports.calendar_tasks') %}
-                        <a href="{{ path('schedule_production_v2') }}"
-                           class="{% if active == 'schedule_production_v2' %}active{% endif %}"
-                        >
-                            {{ 'Kalendarz zadań'|trans }}
                         </a>
                     {% endif %}
                 </div>

--- a/app/templates/schedule/schedule_production.html.twig
+++ b/app/templates/schedule/schedule_production.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 {% trans_default_domain 'schedule' %}
 
-{% block title %}{{ 'Kalendarz produkcji'|trans }}{% endblock %}
+{% block title %}{{ 'Kalendarz ogólny'|trans }}{% endblock %}
 
 {% block body %}
 <app>

--- a/app/translations/dashboard.en.yml
+++ b/app/translations/dashboard.en.yml
@@ -10,7 +10,7 @@ Archiwum: Archived
 Produkcja: Production
 Kalendarze: Calendars
 'Kalendarz ogólny': 'General calendar'
-'Kalendarz zadań': 'Tasks calendar'
+'Kalendarz produkcji': 'Production calendar'
 Konfiguracja: Configuration
 Użytkownicy: Users
 Role: Roles

--- a/app/translations/dashboard.pl.yml
+++ b/app/translations/dashboard.pl.yml
@@ -10,7 +10,7 @@ Archiwum: Archiwum
 Produkcja: Produkcja
 Kalendarze: Kalendarze
 'Kalendarz ogólny': 'Kalendarz ogólny'
-'Kalendarz zadań': 'Kalendarz zadań'
+'Kalendarz produkcji': 'Kalendarz produkcji'
 Konfiguracja: Konfiguracja
 Użytkownicy: Użytkownicy
 Role: Role

--- a/app/translations/schedule.en.yml
+++ b/app/translations/schedule.en.yml
@@ -1,1 +1,3 @@
 Kalendarz: Calendar
+'Kalendarz ogólny': 'General calendar'
+'Kalendarz produkcji': 'Production calendar'


### PR DESCRIPTION
… routes

- Production calendar (CalendarTasks) now serves at /reports/schedule/view/production
- General calendar moves to /reports/schedule/view/production/basic
- Sidebar: production calendar listed first, then the general one
- Set the general calendar page title to "Kalendarz ogólny"
- Add English translations for both calendar titles in the schedule domain