### PR TITLE
Add "Kalendarz zamówień" (orders calendar)

### DIFF
--- a/app/assets/js-vue/src/components/root-components.js
+++ b/app/assets/js-vue/src/components/root-components.js
@@ -35,6 +35,7 @@ export default {
     ProductionConfiguration: () => import('../modules/configuration/views/Production.vue'),
     CalendarGeneral: () => import('../modules/schedule/views/CalendarGeneral.vue'),
     CalendarTasks: () => import('../modules/schedule/views/CalendarTasks.vue'),
+    CalendarOrders: () => import('../modules/schedule/views/CalendarOrders.vue'),
     ...TagsModule,
     ContextMenu,
     DevContainer,

--- a/app/assets/js-vue/src/modules/schedule/components/ResourceCalendar/CalendarGrid.vue
+++ b/app/assets/js-vue/src/modules/schedule/components/ResourceCalendar/CalendarGrid.vue
@@ -162,6 +162,9 @@ export default {
   },
   methods: {
     rowHeight(resourceId) {
+      // A resource may request an explicit fixed height (e.g. compact single-bar rows).
+      const resource = this.resources.find(r => r.id === resourceId)
+      if (resource && resource.rowHeight) return resource.rowHeight
       const data = this.positionedEvents[resourceId]
       if (!data) return 60
       const maxLane = data.events.reduce((max, e) => Math.max(max, e.lane || 0), 0)
@@ -223,7 +226,11 @@ $header-height: 48px;
 
 .calendar-wrapper {
   overflow-x: auto;
-  overflow-y: visible;
+  // Own vertical scroll so the sticky header sticks within it. `200px` is the
+  // assumed space above the calendar (title + filters); tweak if needed. On a
+  // taller filter bar the page may add a second scrollbar — acceptable.
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
   border: 1px solid #dee2e6;
   border-radius: 4px;
   position: relative;

--- a/app/assets/js-vue/src/modules/schedule/components/ResourceCalendar/utils/gridHelpers.js
+++ b/app/assets/js-vue/src/modules/schedule/components/ResourceCalendar/utils/gridHelpers.js
@@ -28,7 +28,9 @@ export const STATUS_COLORS = {
   started:        { bg: '#ffe5d0', border: '#fd7e14', text: '#7a3d00' },
   in_progress:    { bg: '#cff4fc', border: '#0dcaf0', text: '#055160' },
   completed:      { bg: '#d1e7dd', border: '#198754', text: '#0a3622' },
-  not_applicable: { bg: '#e2e3e5', border: '#6c757d', text: '#41464b' }
+  not_applicable: { bg: '#e2e3e5', border: '#6c757d', text: '#41464b' },
+  // Order envelope bar (orders calendar) — uses the app primary colour, distinct from task statuses above
+  order_range:    { bg: 'var(--colorPrimary)', border: 'var(--colorPrimary)', text: '#ffffff' }
 }
 
 export function eventColors(event) {

--- a/app/assets/js-vue/src/modules/schedule/locale/en.js
+++ b/app/assets/js-vue/src/modules/schedule/locale/en.js
@@ -5,6 +5,18 @@ export default {
         'calendar': 'Calendar',
         'calendarV2': 'Calendar v2',
     },
+    'orders': {
+        'title': 'Orders calendar',
+        'breadcrumb': 'Orders calendar',
+        'showDetails': 'Show production',
+        'hideDetails': 'Hide production',
+        'status': {
+            '5': 'Waiting',
+            '10': 'In production',
+            '15': 'Warehouse',
+            '20': 'Archived',
+        },
+    },
     freeDay: 'Free day',
     'weekCapacity': 'Weekly capacity',
     'capacityBurned': 'Capacity burned',

--- a/app/assets/js-vue/src/modules/schedule/locale/pl.js
+++ b/app/assets/js-vue/src/modules/schedule/locale/pl.js
@@ -5,6 +5,18 @@ export default {
         'calendar': 'Kalendarz',
         'calendarV2': 'Kalendarz v2',
     },
+    'orders': {
+        'title': 'Kalendarz zamówień',
+        'breadcrumb': 'Kalendarz zamówień',
+        'showDetails': 'Pokaż produkcję',
+        'hideDetails': 'Ukryj produkcję',
+        'status': {
+            '5': 'Oczekujące',
+            '10': 'W realizacji',
+            '15': 'Magazyn',
+            '20': 'Archiwum',
+        },
+    },
     'freeDay': 'Dzień wolny',
     'weekCapacity': 'Tygodniowa pula współczynników',
     'capacityBurned': 'Współczynniki wykorzystane',

--- a/app/assets/js-vue/src/modules/schedule/repository/scheduleRepository.js
+++ b/app/assets/js-vue/src/modules/schedule/repository/scheduleRepository.js
@@ -29,6 +29,13 @@ export function fetchProductionResources(startDate, endDate, includeGhost = fals
     return axios.get(`/reports/schedule/production-resources?${params.toString()}`)
 }
 
+export function fetchOrderResources(startDate, endDate) {
+    const params = new URLSearchParams()
+    params.append('startDate', startDate)
+    params.append('endDate', endDate)
+    return axios.get(`/reports/schedule/order-resources?${params.toString()}`)
+}
+
 export function updateProductionDates(productionId, { dateStart, dateEnd }) {
     return axios.put(`/production/${productionId}/dates`, { dateStart, dateEnd })
 }

--- a/app/assets/js-vue/src/modules/schedule/views/CalendarOrders.vue
+++ b/app/assets/js-vue/src/modules/schedule/views/CalendarOrders.vue
@@ -1,0 +1,380 @@
+<script>
+import ResourceCalendar from "@/modules/schedule/components/ResourceCalendar/ResourceCalendar.vue";
+import OrderPanelDrawer from "@/modules/agreement/components/OrderPanelDrawer.vue";
+import VueSelect from 'vue-select'
+import moment from 'moment'
+import { fetchOrderResources, updateProductionDates, fetchHolidays } from "@/modules/schedule/repository/scheduleRepository";
+
+// AgreementLine statuses (DELETED is filtered out server-side)
+const ORDER_STATUSES = [5, 10, 15, 20]
+const EDITABLE_STATUSES = ['awaits', 'started', 'in_progress']
+// Compact row height so a single-bar row hugs the bar (bar is 24px tall)
+const ROW_HEIGHT = 32
+
+export default {
+    name: "CalendarOrders",
+
+    components: {
+        ResourceCalendar,
+        OrderPanelDrawer,
+        VueSelect,
+    },
+
+    data() {
+        return {
+            currentMonth: moment().format('YYYY-MM'),
+            loading: false,
+            orders: [],
+            holidays: [],
+            expanded: {},
+            filters: {
+                statuses: [],
+                agreementLineIds: [],
+            },
+            panelLineId: null,
+            panelOpen: false,
+            panelDepartment: null,
+        }
+    },
+
+    computed: {
+        breadcrumbs() {
+            return [
+                { icon: 'home', href: '/', label: this.$t('schedule.breadcrumb.home') },
+                { label: this.$t('schedule.orders.breadcrumb') },
+            ]
+        },
+
+        allLabel() {
+            return this.$t('schedule.all')
+        },
+
+        statusOptions() {
+            return ORDER_STATUSES.map(s => ({
+                value: s,
+                label: this.$t(`schedule.orders.status.${s}`),
+            }))
+        },
+
+        agreementLineOptions() {
+            return this.orders
+                .map(o => ({
+                    value: o.id,
+                    label: [o.orderNumber, o.customerName, o.productName]
+                        .filter(Boolean)
+                        .join(' — ') || `#${o.id}`,
+                    orderNumber: o.orderNumber || '',
+                }))
+                .sort((a, b) => String(a.orderNumber).localeCompare(String(b.orderNumber)))
+        },
+
+        filteredOrders() {
+            const { statuses, agreementLineIds } = this.filters
+            return this.orders.filter(o => {
+                if (statuses.length && !statuses.includes(o.status)) return false
+                if (agreementLineIds.length && !agreementLineIds.includes(o.id)) return false
+                return true
+            })
+        },
+
+        resources() {
+            const rows = []
+            for (const order of this.filteredOrders) {
+                rows.push({ id: 'o' + order.id, type: 'order', order, rowHeight: ROW_HEIGHT })
+                if (this.isExpanded(order.id)) {
+                    for (const p of order.productions) {
+                        rows.push({
+                            id: 'o' + order.id + '-' + p.departmentSlug,
+                            type: 'department',
+                            name: p.departmentName,
+                            rowHeight: ROW_HEIGHT,
+                        })
+                    }
+                }
+            }
+            return rows
+        },
+
+        events() {
+            const events = []
+            for (const order of this.filteredOrders) {
+                const orderName = [order.orderNumber, order.customerName]
+                    .filter(Boolean)
+                    .join(' · ')
+                events.push({
+                    id: 'order-' + order.id,
+                    resourceId: 'o' + order.id,
+                    agreementLineId: order.id,
+                    orderName,
+                    eventType: 'orderRange',
+                    orderStatus: 'order_range',
+                    dateStart: order.dateStart,
+                    dateEnd: order.dateEnd,
+                    meta: {
+                        agreementLineId: order.id,
+                        orderNumber: order.orderNumber,
+                        customerName: order.customerName,
+                        productName: order.productName,
+                    },
+                })
+
+                if (!this.isExpanded(order.id)) continue
+
+                for (const p of order.productions) {
+                    events.push({
+                        id: 'prod-' + p.id,
+                        resourceId: 'o' + order.id + '-' + p.departmentSlug,
+                        agreementLineId: order.id,
+                        orderName: order.orderNumber,
+                        orderStatus: p.status,
+                        eventType: 'order',
+                        dateStart: p.dateStart,
+                        dateEnd: p.dateEnd,
+                        meta: {
+                            productionId: p.id,
+                            agreementLineId: order.id,
+                            departmentSlug: p.departmentSlug,
+                            orderNumber: order.orderNumber,
+                            customerName: order.customerName,
+                            productName: order.productName,
+                        },
+                    })
+                }
+            }
+            return events
+        },
+    },
+
+    created() {
+        this.loadMonth(this.currentMonth)
+    },
+
+    methods: {
+        labelSlot(id) {
+            return 'resource-label-' + id
+        },
+
+        isExpanded(orderId) {
+            return !!this.expanded[orderId]
+        },
+
+        toggle(orderId) {
+            this.expanded = { ...this.expanded, [orderId]: !this.expanded[orderId] }
+        },
+
+        hasDetails(order) {
+            return order.productions && order.productions.length > 0
+        },
+
+        rangeFor(month) {
+            const m = moment(month, 'YYYY-MM')
+            return {
+                start: m.clone().startOf('month').format('YYYY-MM-DD'),
+                end: m.clone().endOf('month').format('YYYY-MM-DD'),
+            }
+        },
+
+        loadMonth(month) {
+            if (false === this.$user.can('reports.calendar_orders')) {
+                return Promise.resolve()
+            }
+            const { start, end } = this.rangeFor(month)
+            this.loading = true
+            this.loadHolidays(start, end)
+            return fetchOrderResources(start, end)
+                .then(({ data }) => {
+                    this.orders = data.orders || []
+                })
+                .catch(() => {
+                    window.EventBus.$emit('message', {
+                        type: 'danger',
+                        content: this.$t('schedule.loadError'),
+                    })
+                })
+                .finally(() => {
+                    this.loading = false
+                })
+        },
+
+        loadHolidays(start, end) {
+            return fetchHolidays(start, end)
+                .then(({ data }) => {
+                    this.holidays = (data || [])
+                        .filter(h => h.date)
+                        .map(h => ({ date: h.date, description: h.description || '' }))
+                })
+                .catch(() => {
+                    this.holidays = []
+                })
+        },
+
+        onMonthChange(month) {
+            this.currentMonth = month
+            this.loadMonth(month)
+        },
+
+        canEditEvent(event) {
+            return event.eventType === 'order'
+                && this.$user.can('production.panel')
+                && EDITABLE_STATUSES.includes(event.orderStatus)
+        },
+
+        onEventClick(event) {
+            this.panelLineId = event.agreementLineId
+            this.panelDepartment = (event.meta && event.meta.departmentSlug) || null
+            this.panelOpen = false
+            this.$nextTick(() => {
+                this.panelOpen = true
+            })
+        },
+
+        onEventMoved({ previous, updated }) {
+            if (
+                previous.dateStart === updated.dateStart
+                && previous.dateEnd === updated.dateEnd
+            ) {
+                return
+            }
+            this.saveDates(updated)
+        },
+
+        onEventResized({ updated }) {
+            this.saveDates(updated)
+        },
+
+        saveDates(event) {
+            const productionId = event.meta && event.meta.productionId
+            if (!productionId) {
+                return
+            }
+            return updateProductionDates(productionId, {
+                dateStart: event.dateStart,
+                dateEnd: event.dateEnd,
+            })
+                .then(() => {
+                    this.applyProductionDates(productionId, event.dateStart, event.dateEnd)
+                    window.EventBus.$emit('message', {
+                        type: 'success',
+                        content: this.$t('schedule.saved'),
+                    })
+                })
+                .catch(() => {
+                    window.EventBus.$emit('message', {
+                        type: 'danger',
+                        content: this.$t('schedule.saveError'),
+                    })
+                    this.loadMonth(this.currentMonth)
+                })
+        },
+
+        applyProductionDates(productionId, dateStart, dateEnd) {
+            for (const order of this.orders) {
+                const target = (order.productions || []).find(p => p.id === productionId)
+                if (target) {
+                    target.dateStart = dateStart
+                    target.dateEnd = dateEnd
+                    return
+                }
+            }
+        },
+
+        onPanelSaved() {
+            this.loadMonth(this.currentMonth)
+        },
+    },
+}
+</script>
+
+<template>
+    <div>
+        <SectionBlockTitle block :title="$t('schedule.orders.title')" :breadcrumbs="breadcrumbs">
+            <template #filters>
+                <div class="row align-items-end">
+                    <div class="col-md-4">
+                        <label class="form-label small mb-1">{{ $t('schedule.filters.status') }}</label>
+                        <vue-select
+                            v-model="filters.statuses"
+                            :options="statusOptions"
+                            :reduce="o => o.value"
+                            :placeholder="allLabel"
+                            multiple
+                        />
+                    </div>
+                    <div class="col-md-5">
+                        <label class="form-label small mb-1">{{ $t('schedule.filters.agreementLine') }}</label>
+                        <vue-select
+                            v-model="filters.agreementLineIds"
+                            :options="agreementLineOptions"
+                            :reduce="o => o.value"
+                            :placeholder="allLabel"
+                            multiple
+                        />
+                    </div>
+                </div>
+            </template>
+        </SectionBlockTitle>
+
+        <SectionBlock class="section-gap">
+            <ResourceCalendar
+                :resources="resources"
+                :events="events"
+                :holidays="holidays"
+                :value="currentMonth"
+                :interactive="true"
+                :allow-create="false"
+                :can-edit-event="canEditEvent"
+                @month-change="onMonthChange"
+                @event-click="onEventClick"
+                @event-moved="onEventMoved"
+                @event-resized="onEventResized"
+            >
+                <!-- Existing per-row label slot, targeted via dynamic slot name (no component change) -->
+                <template v-for="res in resources" #[labelSlot(res.id)]="{ resource: r }">
+                    <button
+                        v-if="r.type === 'order' && hasDetails(r.order)"
+                        :key="r.id"
+                        type="button"
+                        class="btn btn-sm btn-link p-0 text-decoration-none"
+                        @click="toggle(r.order.id)"
+                    >
+                        <font-awesome-icon
+                            :icon="isExpanded(r.order.id) ? 'chevron-down' : 'chevron-right'"
+                            class="mr-1"
+                        />
+                        {{ isExpanded(r.order.id) ? $t('schedule.orders.hideDetails') : $t('schedule.orders.showDetails') }}
+                    </button>
+                    <span v-else-if="r.type === 'department'" :key="r.id" class="department-name">
+                        <font-awesome-icon icon="arrow-right" class="mr-1 text-muted" />{{ r.name }}
+                    </span>
+                </template>
+
+                <template #event-type-orderRange="{ event }">
+                    <span class="event-label fw-semibold">{{ event.orderName }}</span>
+                </template>
+
+                <template #event-type-order="{ event }">
+                    <span class="event-label fw-semibold">{{ event.orderName }}</span>
+                </template>
+            </ResourceCalendar>
+        </SectionBlock>
+
+        <OrderPanelDrawer
+            v-if="panelLineId"
+            :key="panelLineId"
+            v-model="panelOpen"
+            :line-id="panelLineId"
+            :active-department="panelDepartment"
+            @saved="onPanelSaved"
+        />
+    </div>
+</template>
+
+<style scoped lang="scss">
+.department-name {
+    font-size: 13px;
+    color: #6c757d;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+</style>

--- a/app/src/Migrations/Version20260629120000.php
+++ b/app/src/Migrations/Version20260629120000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add new grant reports.calendar_orders for the orders calendar
+ * ("Kalendarz zamówień"), alongside the existing calendar grants.
+ */
+final class Version20260629120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add reports.calendar_orders grant for the orders calendar';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Copy module_id, type and options from an existing calendar grant so we do
+        // not assume the storage format of those columns.
+        $this->addSql(
+            "INSERT INTO auth_grant (module_id, slug, name, description, type, options)
+             SELECT module_id,
+                    'reports.calendar_orders',
+                    'Kalendarz zamówień',
+                    'Dostęp do kalendarza zamówień',
+                    type,
+                    options
+             FROM auth_grant
+             WHERE slug = 'reports.calendar_general'"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Remove dependent grant values first, then the grant itself.
+        $this->addSql(
+            "DELETE FROM auth_role_grant_value
+             WHERE grant_id IN (SELECT id FROM (SELECT id FROM auth_grant WHERE slug = 'reports.calendar_orders') AS g)"
+        );
+        $this->addSql(
+            "DELETE FROM auth_user_grant_value
+             WHERE grant_id IN (SELECT id FROM (SELECT id FROM auth_grant WHERE slug = 'reports.calendar_orders') AS g)"
+        );
+        $this->addSql("DELETE FROM auth_grant WHERE slug = 'reports.calendar_orders'");
+    }
+}

--- a/app/src/Module/Agreement/Repository/AgreementLineRMRepository.php
+++ b/app/src/Module/Agreement/Repository/AgreementLineRMRepository.php
@@ -250,6 +250,21 @@ class AgreementLineRMRepository extends ServiceEntityRepository implements Agree
                     $qb->andWhere("l.q Like :q");
                     $qb->setParameter('q', '%' . $value . '%');
                     break;
+                case 'orderDateRange':
+                    // Zamówienie trwa od daty utworzenia umowy (agreementCreateDate) do potwierdzonej
+                    // daty dostawy (confirmedDate). Zwracamy zamówienia, których zakres nachodzi na okno.
+                    if (
+                        !isset($value['start'], $value['end'])
+                        || \DateTime::createFromFormat('Y-m-d', $value['start']) === false
+                        || \DateTime::createFromFormat('Y-m-d', $value['end']) === false
+                    ) {
+                        break;
+                    }
+                    $qb->andWhere('l.agreementCreateDate <= :ordRangeEnd');
+                    $qb->andWhere('l.confirmedDate >= :ordRangeStart');
+                    $qb->setParameter('ordRangeStart', new \DateTime($value['start'] . ' 00:00:00'));
+                    $qb->setParameter('ordRangeEnd', new \DateTime($value['end'] . ' 23:59:59'));
+                    break;
                 case 'dptDateRange':
                     if (
                         !isset($value['start'], $value['end'], $value['departments'])

--- a/app/src/Module/Reports/Schedule/Controller/ScheduleController.php
+++ b/app/src/Module/Reports/Schedule/Controller/ScheduleController.php
@@ -7,6 +7,7 @@ use App\Entity\AgreementLine;
 use App\Module\Agreement\Repository\AgreementLineRMRepository;
 use App\Module\Reports\Schedule\DTO\ScheduleCapacityDTO;
 use App\Module\Reports\Schedule\Service\ScheduleCapacityService;
+use App\Module\Reports\Schedule\Service\ScheduleOrderResourcesService;
 use App\Module\Reports\Schedule\Service\ScheduleProductionResourcesService;
 use App\Module\WorkConfiguration\Entity\WorkSchedule;
 use App\Module\WorkConfiguration\Service\WorkScheduleService;
@@ -91,6 +92,27 @@ class ScheduleController extends BaseController
 
         return $this->json(
             $service->getCalendarData($start, $end, $includeGhost),
+            Response::HTTP_OK
+        );
+    }
+
+    #[Route(path: '/order-resources', methods: ['GET'])]
+    #[IsGranted('reports.calendar_orders')]
+    public function orderResources(
+        Request $request,
+        ScheduleOrderResourcesService $service
+    ): Response {
+        $result = $this->validateDateRange(
+            $request->query->get('startDate'),
+            $request->query->get('endDate')
+        );
+        if ($result instanceof Response) {
+            return $result;
+        }
+        ['start' => $start, 'end' => $end] = $result;
+
+        return $this->json(
+            $service->getCalendarData($start, $end),
             Response::HTTP_OK
         );
     }

--- a/app/src/Module/Reports/Schedule/Controller/ViewController.php
+++ b/app/src/Module/Reports/Schedule/Controller/ViewController.php
@@ -16,6 +16,13 @@ class ViewController extends BaseController
         return $this->render('schedule/schedule_production_v2.html.twig');
     }
 
+    #[Route(path: '/view/orders', name: 'schedule_orders', methods: ['GET'])]
+    #[IsGranted('reports.calendar_orders')]
+    public function calendarOrders(): Response
+    {
+        return $this->render('schedule/schedule_orders.html.twig');
+    }
+
     #[Route(path: '/view/production/basic', name: 'schedule_production', methods: ['GET'])]
     #[IsGranted('reports.calendar_general')]
     public function index(): Response

--- a/app/src/Module/Reports/Schedule/Service/ScheduleOrderResourcesService.php
+++ b/app/src/Module/Reports/Schedule/Service/ScheduleOrderResourcesService.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Module\Reports\Schedule\Service;
+
+use App\Entity\AgreementLine;
+use App\Module\Agreement\ReadModel\AgreementLineRM;
+use App\Module\Agreement\ReadModel\ProductionRM;
+use App\Module\Agreement\Repository\AgreementLineRMRepository;
+use App\Module\Production\ValueObject\DepartmentEnum;
+use App\Module\Production\ValueObject\ProductionTaskStatus;
+use Symfony\Component\Security\Core\Security;
+
+/**
+ * Buduje dane dla "Kalendarza zamówień": jeden wiersz na zamówienie (AgreementLine),
+ * zakres = agreementCreateDate -> confirmedDate, oraz zadania produkcyjne per dział
+ * (ujawniane po stronie frontu po kliknięciu "pokaż szczegóły").
+ *
+ * W odróżnieniu od kalendarza produkcji zamówienia NIE są bramkowane przez ROLE_PRODUCTION —
+ * gdy użytkownik nie widzi żadnego działu, zwracamy zamówienia bez listy zadań produkcyjnych.
+ */
+class ScheduleOrderResourcesService
+{
+    private const GRANT_BY_DPT = [
+        'dpt01' => 'production.show.gluing',
+        'dpt02' => 'production.show.cnc',
+        'dpt03' => 'production.show.grinding',
+        'dpt04' => 'production.show.laquering',
+        'dpt05' => 'production.show.packing',
+        'dpt06' => 'production.show.intorex',
+    ];
+
+    public function __construct(
+        private readonly AgreementLineRMRepository $agreementLineRepo,
+        private readonly Security $security,
+    ) {
+    }
+
+    /**
+     * @return array{orders: array<int, array<string, mixed>>}
+     */
+    public function getCalendarData(\DateTimeInterface $start, \DateTimeInterface $end): array
+    {
+        $visibleDptSet = array_flip($this->getVisibleDepartments());
+
+        $search = [
+            'statusNot' => [AgreementLine::STATUS_DELETED],
+            'orderDateRange' => [
+                'start' => $start->format('Y-m-d'),
+                'end' => $end->format('Y-m-d'),
+            ],
+            'sort' => 'dateConfirmed_asc',
+        ];
+
+        if ($this->security->isGranted('ROLE_CUSTOMER')) {
+            $user = $this->security->getUser();
+            if ($user === null) {
+                return ['orders' => []];
+            }
+            $search['ownedBy'] = $user;
+        }
+
+        /** @var AgreementLineRM[] $lines */
+        $lines = $this->agreementLineRepo->search(['search' => $search])->getResult();
+
+        $orders = [];
+        foreach ($lines as $line) {
+            $orders[] = [
+                'id' => $line->getAgreementLineId(),
+                'orderNumber' => $line->getOrderNumber(),
+                'customerName' => $line->getCustomerName(),
+                'productName' => $line->getProductName(),
+                'status' => $line->getStatus(),
+                'dateStart' => $line->getAgreementCreateDate()->format('Y-m-d'),
+                'dateEnd' => $line->getConfirmedDate()->format('Y-m-d'),
+                'productions' => $this->buildProductions($line, $visibleDptSet),
+            ];
+        }
+
+        return ['orders' => $orders];
+    }
+
+    /**
+     * @param array<string, int> $visibleDptSet
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildProductions(AgreementLineRM $line, array $visibleDptSet): array
+    {
+        $productions = [];
+        foreach ($line->getProductions() as $production) {
+            if (!isset($visibleDptSet[$production->getDepartmentSlug()])) {
+                continue;
+            }
+            if ($production->isGhost()) {
+                continue;
+            }
+            $dateStart = $production->getDateStart();
+            $dateEnd = $production->getDateEnd();
+            if ($dateStart === null || $dateEnd === null) {
+                continue;
+            }
+            $productions[] = $this->buildProduction($production);
+        }
+
+        return $productions;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildProduction(ProductionRM $production): array
+    {
+        $slug = $production->getDepartmentSlug();
+        $department = DepartmentEnum::tryFrom($slug);
+
+        return [
+            'id' => $production->getId(),
+            'departmentSlug' => $slug,
+            'departmentName' => $department?->getName() ?? $slug,
+            'dateStart' => $production->getDateStart()->format('Y-m-d'),
+            'dateEnd' => $production->getDateEnd()->format('Y-m-d'),
+            'status' => $this->mapStatus($production->getStatus()),
+        ];
+    }
+
+    /**
+     * @return string[] sorted list of dptXX slugs the current user can see
+     */
+    private function getVisibleDepartments(): array
+    {
+        $result = [];
+        foreach (DepartmentEnum::getProductionDepartments() as $dept) {
+            $grant = self::GRANT_BY_DPT[$dept->value] ?? null;
+            if ($grant === null) {
+                continue;
+            }
+            if ($this->security->isGranted($grant)) {
+                $result[] = $dept->value;
+            }
+        }
+
+        return $result;
+    }
+
+    private function mapStatus(?string $status): string
+    {
+        $taskStatus = ProductionTaskStatus::tryFrom((int) $status) ?? ProductionTaskStatus::AWAITS;
+
+        return match ($taskStatus) {
+            ProductionTaskStatus::AWAITS => 'awaits',
+            ProductionTaskStatus::STARTED => 'started',
+            ProductionTaskStatus::IN_PROGRESS => 'in_progress',
+            ProductionTaskStatus::COMPLETED => 'completed',
+            ProductionTaskStatus::NOT_APPLICABLE => 'not_applicable',
+        };
+    }
+}

--- a/app/src/Module/Reports/module.yaml
+++ b/app/src/Module/Reports/module.yaml
@@ -22,3 +22,7 @@ app_module:
       description: Dostęp do kalendarza zadań
       slug: reports.calendar_tasks
       type: boolean
+    - name: Kalendarz zamówień
+      description: Dostęp do kalendarza zamówień
+      slug: reports.calendar_orders
+      type: boolean

--- a/app/templates/_sidebar.html.twig
+++ b/app/templates/_sidebar.html.twig
@@ -104,9 +104,9 @@
             </li>
         {% endif %}
 
-        {% if is_granted('reports.calendar_general') or is_granted('reports.calendar_tasks') %}
+        {% if is_granted('reports.calendar_general') or is_granted('reports.calendar_tasks') or is_granted('reports.calendar_orders') %}
             <menu-item
-                :active="{% if active in ['schedule_production', 'schedule_production_v2'] %}true{% else %}false{% endif %}"
+                :active="{% if active in ['schedule_production', 'schedule_production_v2', 'schedule_orders'] %}true{% else %}false{% endif %}"
                 :title-icon="'fa fa-calendar'"
                 :title="'{{ 'Kalendarze'|trans }}'"
             >
@@ -116,6 +116,13 @@
                            class="{% if active == 'schedule_production_v2' %}active{% endif %}"
                         >
                             {{ 'Kalendarz produkcji'|trans }}
+                        </a>
+                    {% endif %}
+                    {% if is_granted('reports.calendar_orders') %}
+                        <a href="{{ path('schedule_orders') }}"
+                           class="{% if active == 'schedule_orders' %}active{% endif %}"
+                        >
+                            {{ 'Kalendarz zamówień'|trans }}
                         </a>
                     {% endif %}
                     {% if is_granted('reports.calendar_general') %}

--- a/app/templates/schedule/schedule_orders.html.twig
+++ b/app/templates/schedule/schedule_orders.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+{% trans_default_domain 'schedule' %}
+
+{% block title %}{{ 'Kalendarz zamówień'|trans }}{% endblock %}
+
+{% block body %}
+<app>
+    <calendar-orders></calendar-orders>
+</app>
+{% endblock %}

--- a/app/tests/End2End/Modules/Reports/Schedule/ScheduleOrderResourcesControllerTest.php
+++ b/app/tests/End2End/Modules/Reports/Schedule/ScheduleOrderResourcesControllerTest.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace App\Tests\End2End\Modules\Reports\Schedule;
+
+use App\Entity\AgreementLine;
+use App\Entity\Customer;
+use App\Module\Agreement\ReadModel\AgreementLineRM;
+use App\Module\Agreement\ReadModel\ProductionRM;
+use App\Tests\Utilities\Factory\EntityFactory;
+use Faker\Factory;
+
+class ScheduleOrderResourcesControllerTest extends BaseScheduleReportsTestCase
+{
+    private EntityFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->getManager()->beginTransaction();
+        $this->factory = new EntityFactory($this->getManager());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->getManager()->rollback();
+        parent::tearDown();
+    }
+
+    public function testShouldReturn403WhenUserHasNoCalendarOrdersGrant(): void
+    {
+        // Given
+        $user = $this->createUser();
+        $client = $this->login($user);
+
+        // When
+        $client->xmlHttpRequest('GET', '/reports/schedule/order-resources?startDate=2026-05-01&endDate=2026-05-31');
+
+        // Then
+        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+    }
+
+    public function testShouldReturnOrderWithProductionsForVisibleDepartmentsOnly(): void
+    {
+        // Given
+        $em = $this->getManager();
+        $user = $this->createUser([], [], ['reports.calendar_orders', 'production.show.gluing'], ['ROLE_PRODUCTION']);
+        $client = $this->login($user);
+
+        $customer = $this->factory->make(Customer::class);
+        $em->flush();
+
+        // confirmedDate = 2026-05-08, agreementCreateDate = 2026-05-01 (overlaps May window)
+        $this->makeLineWithProductions(
+            id: 1001,
+            orderNumber: 'AL-1001',
+            customerId: $customer->getId(),
+            productions: [
+                ['slug' => 'dpt01', 'start' => '2026-05-08', 'end' => '2026-05-12', 'status' => '1', 'isGhost' => false, 'id' => 5001],
+                ['slug' => 'dpt02', 'start' => '2026-05-13', 'end' => '2026-05-15', 'status' => '0', 'isGhost' => false, 'id' => 5002],
+            ],
+        );
+        $em->flush();
+        $em->clear();
+
+        // When
+        $client->xmlHttpRequest('GET', '/reports/schedule/order-resources?startDate=2026-05-01&endDate=2026-05-31');
+
+        // Then
+        $response = $client->getResponse();
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $content = json_decode($response->getContent(), true);
+        $this->assertCount(1, $content['orders']);
+
+        $order = $content['orders'][0];
+        $this->assertSame(1001, $order['id']);
+        $this->assertSame('AL-1001', $order['orderNumber']);
+        $this->assertSame('2026-05-08', $order['dateEnd']);
+        $this->assertSame('2026-05-01', $order['dateStart']);
+
+        // dpt02 is not granted -> only dpt01 production is returned
+        $this->assertCount(1, $order['productions']);
+        $this->assertSame(5001, $order['productions'][0]['id']);
+        $this->assertSame('dpt01', $order['productions'][0]['departmentSlug']);
+        $this->assertSame('started', $order['productions'][0]['status']);
+        $this->assertSame('2026-05-08', $order['productions'][0]['dateStart']);
+    }
+
+    public function testShouldReturnOrderWithoutProductionsWhenNoDepartmentVisible(): void
+    {
+        // Given — user can see the calendar but has no production department grants
+        $em = $this->getManager();
+        $user = $this->createUser([], [], ['reports.calendar_orders']);
+        $client = $this->login($user);
+
+        $customer = $this->factory->make(Customer::class);
+        $em->flush();
+
+        $this->makeLineWithProductions(
+            id: 2001,
+            orderNumber: 'AL-2001',
+            customerId: $customer->getId(),
+            productions: [
+                ['slug' => 'dpt01', 'start' => '2026-05-08', 'end' => '2026-05-12', 'status' => '1', 'isGhost' => false, 'id' => 6001],
+            ],
+        );
+        $em->flush();
+        $em->clear();
+
+        // When
+        $client->xmlHttpRequest('GET', '/reports/schedule/order-resources?startDate=2026-05-01&endDate=2026-05-31');
+
+        // Then — order is visible, but its productions are empty (not production-gated)
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $content = json_decode($client->getResponse()->getContent(), true);
+        $this->assertCount(1, $content['orders']);
+        $this->assertSame('AL-2001', $content['orders'][0]['orderNumber']);
+        $this->assertSame([], $content['orders'][0]['productions']);
+    }
+
+    public function testShouldFilterOrdersByRangeOverlap(): void
+    {
+        // Given
+        $em = $this->getManager();
+        $user = $this->createUser([], [], ['reports.calendar_orders']);
+        $client = $this->login($user);
+
+        $customer = $this->factory->make(Customer::class);
+        $em->flush();
+
+        // Out of window: confirmedDate 2026-03-10, createDate 2026-03-03 — both before May
+        $this->makeLineWithProductions(
+            id: 3001,
+            orderNumber: 'AL-3001',
+            customerId: $customer->getId(),
+            productions: [
+                ['slug' => 'dpt01', 'start' => '2026-03-10', 'end' => '2026-03-12', 'status' => '1', 'isGhost' => false, 'id' => 7001],
+            ],
+        );
+        // In window: confirmedDate 2026-05-20
+        $this->makeLineWithProductions(
+            id: 3002,
+            orderNumber: 'AL-3002',
+            customerId: $customer->getId(),
+            productions: [
+                ['slug' => 'dpt01', 'start' => '2026-05-20', 'end' => '2026-05-22', 'status' => '1', 'isGhost' => false, 'id' => 7002],
+            ],
+        );
+        $em->flush();
+        $em->clear();
+
+        // When
+        $client->xmlHttpRequest('GET', '/reports/schedule/order-resources?startDate=2026-05-01&endDate=2026-05-31');
+
+        // Then
+        $content = json_decode($client->getResponse()->getContent(), true);
+        $this->assertCount(1, $content['orders']);
+        $this->assertSame('AL-3002', $content['orders'][0]['orderNumber']);
+    }
+
+    public function testShouldRestrictByOwnedCustomersForRoleCustomer(): void
+    {
+        // Given
+        $em = $this->getManager();
+        $user = $this->createUser([], [], ['reports.calendar_orders'], ['ROLE_CUSTOMER']);
+        $client = $this->login($user);
+
+        $customerA = $this->factory->make(Customer::class);
+        $customerB = $this->factory->make(Customer::class);
+        $em->flush();
+
+        $user->addCustomer($customerA);
+        $em->flush();
+
+        $this->makeLineWithProductions(
+            id: 4001,
+            orderNumber: 'AL-4001',
+            customerId: $customerA->getId(),
+            productions: [
+                ['slug' => 'dpt01', 'start' => '2026-05-08', 'end' => '2026-05-10', 'status' => '1', 'isGhost' => false, 'id' => 8001],
+            ],
+        );
+        $this->makeLineWithProductions(
+            id: 4002,
+            orderNumber: 'AL-4002',
+            customerId: $customerB->getId(),
+            productions: [
+                ['slug' => 'dpt01', 'start' => '2026-05-12', 'end' => '2026-05-14', 'status' => '1', 'isGhost' => false, 'id' => 8002],
+            ],
+        );
+        $em->flush();
+        $em->clear();
+
+        // When
+        $client->xmlHttpRequest('GET', '/reports/schedule/order-resources?startDate=2026-05-01&endDate=2026-05-31');
+
+        // Then
+        $content = json_decode($client->getResponse()->getContent(), true);
+        $this->assertCount(1, $content['orders']);
+        $this->assertSame('AL-4001', $content['orders'][0]['orderNumber']);
+    }
+
+    /**
+     * @param array<int, array{slug: string, start: string, end: string, status: string, isGhost: bool, id: int}> $productions
+     */
+    private function makeLineWithProductions(
+        int $id,
+        string $orderNumber,
+        int $customerId,
+        array $productions,
+        bool $hasProduction = true,
+    ): AgreementLineRM {
+        $faker = Factory::create();
+        $em = $this->getManager();
+
+        $confirmedDate = new \DateTime($productions[0]['start']);
+
+        $rm = new AgreementLineRM($id);
+        $rm->setConfirmedDate($confirmedDate);
+        $rm->setStatus(AgreementLine::STATUS_MANUFACTURING);
+        $rm->setIsDeleted(false);
+        $rm->setIsArchived(false);
+        $rm->setHasProduction($hasProduction);
+        $rm->setOrderNumber($orderNumber);
+        $rm->setQ($faker->text(30));
+        $rm->setCustomerName($faker->name);
+        $rm->setProductName($faker->word);
+        $rm->setAgreementCreateDate((clone $confirmedDate)->modify('-1 week'));
+        $rm->setAgreementId($faker->randomDigit());
+        $rm->setCustomerId($customerId);
+        $rm->setFactor(1.0);
+
+        $prodModels = [];
+        $byDpt = [];
+        foreach ($productions as $p) {
+            $prod = new ProductionRM(departmentSlug: $p['slug']);
+            $prod->setId($p['id']);
+            $prod->setDateStart(new \DateTime($p['start']));
+            $prod->setDateEnd(new \DateTime($p['end']));
+            $prod->setStatus($p['status']);
+            $prod->setIsGhost($p['isGhost']);
+            $prodModels[] = $prod;
+            if (!isset($byDpt[$p['slug']])) {
+                $byDpt[$p['slug']] = $prod;
+            }
+        }
+        $rm->setProductions($prodModels);
+
+        $setters = [
+            'dpt01' => ['setDpt01StartDate', 'setDpt01EndDate'],
+            'dpt02' => ['setDpt02StartDate', 'setDpt02EndDate'],
+            'dpt03' => ['setDpt03StartDate', 'setDpt03EndDate'],
+            'dpt04' => ['setDpt04StartDate', 'setDpt04EndDate'],
+            'dpt05' => ['setDpt05StartDate', 'setDpt05EndDate'],
+            'dpt06' => ['setDpt06StartDate', 'setDpt06EndDate'],
+        ];
+        foreach ($setters as $slug => [$setStart, $setEnd]) {
+            if (isset($byDpt[$slug])) {
+                $rm->{$setStart}($byDpt[$slug]->getDateStart());
+                $rm->{$setEnd}($byDpt[$slug]->getDateEnd());
+            } else {
+                $rm->{$setStart}(null);
+                $rm->{$setEnd}(null);
+            }
+        }
+
+        $em->persist($rm);
+        return $rm;
+    }
+}

--- a/app/translations/dashboard.en.yml
+++ b/app/translations/dashboard.en.yml
@@ -11,6 +11,7 @@ Produkcja: Production
 Kalendarze: Calendars
 'Kalendarz ogólny': 'General calendar'
 'Kalendarz produkcji': 'Production calendar'
+'Kalendarz zamówień': 'Orders calendar'
 Konfiguracja: Configuration
 Użytkownicy: Users
 Role: Roles

--- a/app/translations/dashboard.pl.yml
+++ b/app/translations/dashboard.pl.yml
@@ -11,6 +11,7 @@ Produkcja: Produkcja
 Kalendarze: Kalendarze
 'Kalendarz ogólny': 'Kalendarz ogólny'
 'Kalendarz produkcji': 'Kalendarz produkcji'
+'Kalendarz zamówień': 'Kalendarz zamówień'
 Konfiguracja: Konfiguracja
 Użytkownicy: Użytkownicy
 Role: Role

--- a/app/translations/schedule.en.yml
+++ b/app/translations/schedule.en.yml
@@ -1,3 +1,4 @@
 Kalendarz: Calendar
 'Kalendarz ogólny': 'General calendar'
 'Kalendarz produkcji': 'Production calendar'
+'Kalendarz zamówień': 'Orders calendar'


### PR DESCRIPTION
A sibling calendar to "Kalendarz produkcji" that flips the model: each row is one order (AgreementLine), the bar spans Agreement.createDate -> confirmedDate, and the order details render on the bar itself. A "Pokaż produkcję" button in the sticky left column expands per-department rows with that order's production tasks, behaving exactly like the production calendar (drag/resize to persist dates, click to open OrderPanelDrawer).

Backend:
- New read-only endpoint GET /reports/schedule/order-resources sourced from AgreementLineRM, with an `orderDateRange` overlap filter on the RM repository.
- ScheduleOrderResourcesService returns orders + per-department productions, filtered by the user's visible departments (orders themselves are not production-gated).
- New view route schedule_orders + twig, new grant reports.calendar_orders (module.yaml + migration), sidebar entry.
- E2E coverage (ScheduleOrderResourcesControllerTest).

Frontend:
- CalendarOrders.vue reuses the shared ResourceCalendar via its existing slots (dynamic resource-label-<id> for the toggle, event-type-* for bars); status and order filters mirror the production calendar.
- gridHelpers: distinct order_range bar colour (var(--colorPrimary)).
- CalendarGrid: per-resource explicit rowHeight (compact order rows) and a static max-height so the sticky header works.