### PR TITLE
Show Authorization module roles on the user lists

### DIFF
--- a/app/assets/js-vue/src/components/base/Menu/ContextMenu/ImpersonateUser.vue
+++ b/app/assets/js-vue/src/components/base/Menu/ContextMenu/ImpersonateUser.vue
@@ -71,6 +71,11 @@ export default defineComponent({
                         <td>{{ user.firstName }}</td>
                         <td>{{ user.lastName }}</td>
                         <td>
+                            <span v-for="name in (user.authRoles || [])" :key="name">
+                                <span class="badge badge-secondary mr-1">{{ name }}</span>
+                            </span>
+                        </td>
+                        <td>
                             <button class="btn btn-primary btn-sm" @click="onImpersonate(user.email)">Przeloguj</button>
                         </td>
                     </tr>

--- a/app/assets/js-vue/src/components/users/UsersList.vue
+++ b/app/assets/js-vue/src/components/users/UsersList.vue
@@ -27,7 +27,8 @@
                                 <th>Imię</th>
                                 <th>Nazwisko</th>
                                 <th>Email</th>
-                                <th>Rola w systemie</th>
+                                <th>Role</th>
+                                <th>Role (nowy system)</th>
                                 <th>Aktywny</th>
                                 <th>Akcje</th>
                             </tr>
@@ -42,6 +43,11 @@
                                 <td>
                                     <span v-for="role in user.roles" :key="role">
                                         <span class="badge badge-info mr-1">{{ getRoleName(role) }}</span>
+                                    </span>
+                                </td>
+                                <td>
+                                    <span v-for="name in (user.authRoles || [])" :key="name">
+                                        <span class="badge badge-secondary mr-1">{{ name }}</span>
                                     </span>
                                 </td>
                                 <td>

--- a/app/src/Controller/SecurityController.php
+++ b/app/src/Controller/SecurityController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\User;
 use App\Form\UserSecurityFormType;
+use App\Module\Authorization\Repository\AuthUserRoleRepository;
 use App\Module\Authorization\Service\GrantsResolver;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -15,6 +16,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -90,13 +92,25 @@ class SecurityController extends BaseController
      * Zwraca wszystkich użytkowników
      */
     #[Route(path: '/users/fetch', name: 'users_fetch', options: ['expose' => true], methods: ['GET'])]
-    public function fetchUsers(Request $request, UserRepository $repository): JsonResponse
-    {
+    public function fetchUsers(
+        Request $request,
+        UserRepository $repository,
+        NormalizerInterface $normalizer,
+        AuthUserRoleRepository $userRoleRepository
+    ): JsonResponse {
         $all = $request->query->getBoolean('all');
         $users = $all ? $repository->findAll() : $repository->findBy(['active' => true]);
-        return $this->json($users, Response::HTTP_OK, [], [
+
+        $rolesByUserId = $userRoleRepository->findRoleNamesGroupedByUserId();
+        $data = $normalizer->normalize($users, null, [
             ObjectNormalizer::GROUPS => ['user_main']
         ]);
+
+        foreach ($data as &$user) {
+            $user['authRoles'] = $rolesByUserId[$user['id']] ?? [];
+        }
+
+        return $this->json($data);
     }
 
     /**

--- a/app/src/Module/Authorization/Repository/AuthUserRoleRepository.php
+++ b/app/src/Module/Authorization/Repository/AuthUserRoleRepository.php
@@ -47,6 +47,27 @@ class AuthUserRoleRepository extends ServiceEntityRepository implements AuthUser
         ;
     }
 
+    /**
+     * @return array<int, string[]> mapa userId -> nazwy ról
+     */
+    public function findRoleNamesGroupedByUserId(): array
+    {
+        $rows = $this->createQueryBuilder('ur')
+            ->select('IDENTITY(ur.user) AS userId', 'r.name AS name')
+            ->innerJoin('ur.role', 'r')
+            ->orderBy('r.name', 'ASC')
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[(int) $row['userId']][] = $row['name'];
+        }
+
+        return $map;
+    }
+
     public function remove(AuthUserRole $userRole, bool $flush = true): void
     {
         $this->_em->remove($userRole);

--- a/app/src/Module/Authorization/Repository/Interface/AuthUserRoleRepositoryInterface.php
+++ b/app/src/Module/Authorization/Repository/Interface/AuthUserRoleRepositoryInterface.php
@@ -9,4 +9,9 @@ interface AuthUserRoleRepositoryInterface
 {
     public function add(AuthUserRole $userRole, bool $flush = true): void;
     public function findAllByUser(User $user): array;
+
+    /**
+     * @return array<int, string[]> mapa userId -> nazwy ról
+     */
+    public function findRoleNamesGroupedByUserId(): array;
 }

--- a/app/src/Module/Authorization/Repository/Test/AuthUserRoleTestRepository.php
+++ b/app/src/Module/Authorization/Repository/Test/AuthUserRoleTestRepository.php
@@ -26,6 +26,23 @@ class AuthUserRoleTestRepository implements AuthUserRoleRepositoryInterface
         $this->storage[] = $userRole;
     }
 
+    /**
+     * @return array<int, string[]> mapa userId -> nazwy ról
+     */
+    public function findRoleNamesGroupedByUserId(): array
+    {
+        $map = [];
+        foreach ($this->storage as $userRole) {
+            $map[(int) $userRole->getUser()->getId()][] = $userRole->getRole()->getName();
+        }
+
+        foreach ($map as &$names) {
+            sort($names);
+        }
+
+        return $map;
+    }
+
     private function find(?User $user, ?AuthRole $role): array
     {
         return array_filter(

--- a/app/tests/End2End/Controller/SecurityControllerTest.php
+++ b/app/tests/End2End/Controller/SecurityControllerTest.php
@@ -20,11 +20,18 @@ class SecurityControllerTest extends ApiTestCase
 
     protected function setUp(): void
     {
+        $this->getManager()->beginTransaction();
         $factory = new EntityFactory($this->getManager());
         $this->faker = $factory->getFaker();
         $this->customer = $factory->make(Customer::class);
         $this->user = $factory->make(User::class, ['roles' => ['ROLE_ADMIN']]);
         $this->getManager()->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->getManager()->rollback();
+        parent::tearDown();
     }
 
     public function testShouldCreateUserWithCustomerRoleAndAssignedCustomers(): void
@@ -63,5 +70,31 @@ class SecurityControllerTest extends ApiTestCase
         $this->assertCount(1, $c2u);
         $this->assertEquals($connection->getCustomer()->getId(), $this->customer->getId());
         $this->assertEquals($connection->getUser()->getId(), $newUserId);
+    }
+
+    public function testShouldReturnAuthRolesWithFetchedUsers(): void
+    {
+        // Given
+        $withRoles = $this->createUser([], ['Kierownik produkcji', 'Handlowiec']);
+        $withoutRoles = $this->createUser();
+        $this->getManager()->flush();
+
+        $client = $this->login($this->user);
+
+        // When
+        $client->xmlHttpRequest('GET', '/users/fetch?all=true');
+
+        // Then
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $users = json_decode($client->getResponse()->getContent(), true);
+        $byId = array_column($users, null, 'id');
+
+        $this->assertEquals(
+            ['Handlowiec', 'Kierownik produkcji'],
+            $byId[$withRoles->getId()]['authRoles']
+        );
+        $this->assertEquals([], $byId[$withoutRoles->getId()]['authRoles']);
+        $this->assertArrayHasKey('email', $byId[$withoutRoles->getId()]);
+        $this->assertArrayHasKey('active', $byId[$withoutRoles->getId()]);
     }
 }


### PR DESCRIPTION
The users table and the impersonation widget only showed legacy Symfony roles, so checking a user's assignment in the new roles module meant opening each user separately. Both views already share the same source (/users/fetch), so the roles ride along in that payload as authRoles.

A single grouped query feeds the whole list, so the extra field costs one query per request regardless of the number of users. User stays free of a relation to AuthUserRole - it is a legacy entity outside the module and the relation would pull roles into every serialization of a user.